### PR TITLE
[chore] Prepare release v1.35.0/v0.129.0

### DIFF
--- a/CHANGELOG-API.md
+++ b/CHANGELOG-API.md
@@ -7,6 +7,10 @@ If you are looking for user-facing changes, check out [CHANGELOG.md](./CHANGELOG
 
 <!-- next version -->
 
+## v1.35.0/v0.129.0
+
+<!-- previous-version -->
+
 ## v1.34.1/v0.128.1
 
 ### 🛑 Breaking changes 🛑

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ If you are looking for developer-facing changes, check out [CHANGELOG-API.md](./
 
 <!-- next version -->
 
+## v1.35.0/v0.129.0
+
+<!-- previous-version -->
+
 ## v1.34.1/v0.128.1
 
 ### 🛑 Breaking changes 🛑

--- a/client/go.mod
+++ b/client/go.mod
@@ -4,8 +4,8 @@ go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0
-	go.opentelemetry.io/collector/consumer v1.34.1
-	go.opentelemetry.io/collector/pdata v1.34.1
+	go.opentelemetry.io/collector/consumer v1.35.0
+	go.opentelemetry.io/collector/pdata v1.35.0
 	go.uber.org/goleak v1.3.0
 )
 

--- a/cmd/builder/internal/builder/config.go
+++ b/cmd/builder/internal/builder/config.go
@@ -19,7 +19,7 @@ import (
 
 const (
 	defaultBetaOtelColVersion   = "v0.128.1"
-	defaultStableOtelColVersion = "v1.34.1"
+	defaultStableOtelColVersion = "v1.35.0"
 )
 
 // errMissingGoMod indicates an empty gomod field

--- a/cmd/builder/internal/builder/config.go
+++ b/cmd/builder/internal/builder/config.go
@@ -18,7 +18,7 @@ import (
 )
 
 const (
-	defaultBetaOtelColVersion   = "v0.128.1"
+	defaultBetaOtelColVersion   = "v0.129.0"
 	defaultStableOtelColVersion = "v1.35.0"
 )
 

--- a/cmd/builder/internal/config/default.yaml
+++ b/cmd/builder/internal/config/default.yaml
@@ -30,9 +30,9 @@ connectors:
   - gomod: go.opentelemetry.io/collector/connector/forwardconnector v0.128.1
 
 providers:
-  - gomod: go.opentelemetry.io/collector/confmap/provider/envprovider v1.34.1
-  - gomod: go.opentelemetry.io/collector/confmap/provider/fileprovider v1.34.1
-  - gomod: go.opentelemetry.io/collector/confmap/provider/httpprovider v1.34.1
-  - gomod: go.opentelemetry.io/collector/confmap/provider/httpsprovider v1.34.1
-  - gomod: go.opentelemetry.io/collector/confmap/provider/yamlprovider v1.34.1
+  - gomod: go.opentelemetry.io/collector/confmap/provider/envprovider v1.35.0
+  - gomod: go.opentelemetry.io/collector/confmap/provider/fileprovider v1.35.0
+  - gomod: go.opentelemetry.io/collector/confmap/provider/httpprovider v1.35.0
+  - gomod: go.opentelemetry.io/collector/confmap/provider/httpsprovider v1.35.0
+  - gomod: go.opentelemetry.io/collector/confmap/provider/yamlprovider v1.35.0
 

--- a/cmd/builder/internal/config/default.yaml
+++ b/cmd/builder/internal/config/default.yaml
@@ -10,24 +10,24 @@ dist:
   module: go.opentelemetry.io/collector/cmd/otelcorecol
   name: otelcorecol
   description: Local OpenTelemetry Collector binary, testing only.
-  version: 0.128.1-dev
+  version: 0.129.0-dev
 
 receivers:
-  - gomod: go.opentelemetry.io/collector/receiver/nopreceiver v0.128.1
-  - gomod: go.opentelemetry.io/collector/receiver/otlpreceiver v0.128.1
+  - gomod: go.opentelemetry.io/collector/receiver/nopreceiver v0.129.0
+  - gomod: go.opentelemetry.io/collector/receiver/otlpreceiver v0.129.0
 exporters:
-  - gomod: go.opentelemetry.io/collector/exporter/debugexporter v0.128.1
-  - gomod: go.opentelemetry.io/collector/exporter/nopexporter v0.128.1
-  - gomod: go.opentelemetry.io/collector/exporter/otlpexporter v0.128.1
-  - gomod: go.opentelemetry.io/collector/exporter/otlphttpexporter v0.128.1
+  - gomod: go.opentelemetry.io/collector/exporter/debugexporter v0.129.0
+  - gomod: go.opentelemetry.io/collector/exporter/nopexporter v0.129.0
+  - gomod: go.opentelemetry.io/collector/exporter/otlpexporter v0.129.0
+  - gomod: go.opentelemetry.io/collector/exporter/otlphttpexporter v0.129.0
 extensions:
-  - gomod: go.opentelemetry.io/collector/extension/memorylimiterextension v0.128.1
-  - gomod: go.opentelemetry.io/collector/extension/zpagesextension v0.128.1
+  - gomod: go.opentelemetry.io/collector/extension/memorylimiterextension v0.129.0
+  - gomod: go.opentelemetry.io/collector/extension/zpagesextension v0.129.0
 processors:
-  - gomod: go.opentelemetry.io/collector/processor/batchprocessor v0.128.1
-  - gomod: go.opentelemetry.io/collector/processor/memorylimiterprocessor v0.128.1
+  - gomod: go.opentelemetry.io/collector/processor/batchprocessor v0.129.0
+  - gomod: go.opentelemetry.io/collector/processor/memorylimiterprocessor v0.129.0
 connectors:
-  - gomod: go.opentelemetry.io/collector/connector/forwardconnector v0.128.1
+  - gomod: go.opentelemetry.io/collector/connector/forwardconnector v0.129.0
 
 providers:
   - gomod: go.opentelemetry.io/collector/confmap/provider/envprovider v1.35.0

--- a/cmd/builder/test/core.builder.yaml
+++ b/cmd/builder/test/core.builder.yaml
@@ -4,10 +4,10 @@ dist:
   go: ${GOBIN}
 
 extensions:
-  - gomod: go.opentelemetry.io/collector/extension/zpagesextension v0.128.1
+  - gomod: go.opentelemetry.io/collector/extension/zpagesextension v0.129.0
 
 receivers:
-  - gomod: go.opentelemetry.io/collector/receiver/otlpreceiver v0.128.1
+  - gomod: go.opentelemetry.io/collector/receiver/otlpreceiver v0.129.0
 
 exporters:
-  - gomod: go.opentelemetry.io/collector/exporter/debugexporter v0.128.1
+  - gomod: go.opentelemetry.io/collector/exporter/debugexporter v0.129.0

--- a/cmd/mdatagen/go.mod
+++ b/cmd/mdatagen/go.mod
@@ -6,20 +6,20 @@ require (
 	github.com/google/go-cmp v0.7.0
 	github.com/spf13/cobra v1.9.1
 	github.com/stretchr/testify v1.10.0
-	go.opentelemetry.io/collector/component v1.34.1
+	go.opentelemetry.io/collector/component v1.35.0
 	go.opentelemetry.io/collector/component/componenttest v0.128.1
-	go.opentelemetry.io/collector/confmap v1.34.1
-	go.opentelemetry.io/collector/confmap/provider/fileprovider v1.34.1
+	go.opentelemetry.io/collector/confmap v1.35.0
+	go.opentelemetry.io/collector/confmap/provider/fileprovider v1.35.0
 	go.opentelemetry.io/collector/connector v0.128.1
 	go.opentelemetry.io/collector/connector/connectortest v0.128.1
-	go.opentelemetry.io/collector/consumer v1.34.1
+	go.opentelemetry.io/collector/consumer v1.35.0
 	go.opentelemetry.io/collector/consumer/consumertest v0.128.1
 	go.opentelemetry.io/collector/filter v0.128.1
-	go.opentelemetry.io/collector/pdata v1.34.1
+	go.opentelemetry.io/collector/pdata v1.35.0
 	go.opentelemetry.io/collector/pipeline v0.128.1
-	go.opentelemetry.io/collector/processor v1.34.1
+	go.opentelemetry.io/collector/processor v1.35.0
 	go.opentelemetry.io/collector/processor/processortest v0.128.1
-	go.opentelemetry.io/collector/receiver v1.34.1
+	go.opentelemetry.io/collector/receiver v1.35.0
 	go.opentelemetry.io/collector/receiver/receivertest v0.128.1
 	go.opentelemetry.io/collector/scraper v0.128.1
 	go.opentelemetry.io/collector/scraper/scrapertest v0.128.1
@@ -57,7 +57,7 @@ require (
 	go.opentelemetry.io/collector/connector/xconnector v0.128.1 // indirect
 	go.opentelemetry.io/collector/consumer/consumererror v0.128.1 // indirect
 	go.opentelemetry.io/collector/consumer/xconsumer v0.128.1 // indirect
-	go.opentelemetry.io/collector/featuregate v1.34.1 // indirect
+	go.opentelemetry.io/collector/featuregate v1.35.0 // indirect
 	go.opentelemetry.io/collector/internal/fanoutconsumer v0.128.1 // indirect
 	go.opentelemetry.io/collector/internal/telemetry v0.128.1 // indirect
 	go.opentelemetry.io/collector/pdata/pprofile v0.128.1 // indirect

--- a/cmd/mdatagen/go.mod
+++ b/cmd/mdatagen/go.mod
@@ -7,22 +7,22 @@ require (
 	github.com/spf13/cobra v1.9.1
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/component v1.35.0
-	go.opentelemetry.io/collector/component/componenttest v0.128.1
+	go.opentelemetry.io/collector/component/componenttest v0.129.0
 	go.opentelemetry.io/collector/confmap v1.35.0
 	go.opentelemetry.io/collector/confmap/provider/fileprovider v1.35.0
-	go.opentelemetry.io/collector/connector v0.128.1
-	go.opentelemetry.io/collector/connector/connectortest v0.128.1
+	go.opentelemetry.io/collector/connector v0.129.0
+	go.opentelemetry.io/collector/connector/connectortest v0.129.0
 	go.opentelemetry.io/collector/consumer v1.35.0
-	go.opentelemetry.io/collector/consumer/consumertest v0.128.1
-	go.opentelemetry.io/collector/filter v0.128.1
+	go.opentelemetry.io/collector/consumer/consumertest v0.129.0
+	go.opentelemetry.io/collector/filter v0.129.0
 	go.opentelemetry.io/collector/pdata v1.35.0
-	go.opentelemetry.io/collector/pipeline v0.128.1
+	go.opentelemetry.io/collector/pipeline v0.129.0
 	go.opentelemetry.io/collector/processor v1.35.0
-	go.opentelemetry.io/collector/processor/processortest v0.128.1
+	go.opentelemetry.io/collector/processor/processortest v0.129.0
 	go.opentelemetry.io/collector/receiver v1.35.0
-	go.opentelemetry.io/collector/receiver/receivertest v0.128.1
-	go.opentelemetry.io/collector/scraper v0.128.1
-	go.opentelemetry.io/collector/scraper/scrapertest v0.128.1
+	go.opentelemetry.io/collector/receiver/receivertest v0.129.0
+	go.opentelemetry.io/collector/scraper v0.129.0
+	go.opentelemetry.io/collector/scraper/scrapertest v0.129.0
 	go.opentelemetry.io/otel v1.36.0
 	go.opentelemetry.io/otel/metric v1.36.0
 	go.opentelemetry.io/otel/sdk/metric v1.36.0
@@ -53,18 +53,18 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/spf13/pflag v1.0.6 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
-	go.opentelemetry.io/collector/component/componentstatus v0.128.1 // indirect
-	go.opentelemetry.io/collector/connector/xconnector v0.128.1 // indirect
-	go.opentelemetry.io/collector/consumer/consumererror v0.128.1 // indirect
-	go.opentelemetry.io/collector/consumer/xconsumer v0.128.1 // indirect
+	go.opentelemetry.io/collector/component/componentstatus v0.129.0 // indirect
+	go.opentelemetry.io/collector/connector/xconnector v0.129.0 // indirect
+	go.opentelemetry.io/collector/consumer/consumererror v0.129.0 // indirect
+	go.opentelemetry.io/collector/consumer/xconsumer v0.129.0 // indirect
 	go.opentelemetry.io/collector/featuregate v1.35.0 // indirect
-	go.opentelemetry.io/collector/internal/fanoutconsumer v0.128.1 // indirect
-	go.opentelemetry.io/collector/internal/telemetry v0.128.1 // indirect
-	go.opentelemetry.io/collector/pdata/pprofile v0.128.1 // indirect
-	go.opentelemetry.io/collector/pdata/testdata v0.128.1 // indirect
-	go.opentelemetry.io/collector/pipeline/xpipeline v0.128.1 // indirect
-	go.opentelemetry.io/collector/processor/xprocessor v0.128.1 // indirect
-	go.opentelemetry.io/collector/receiver/xreceiver v0.128.1 // indirect
+	go.opentelemetry.io/collector/internal/fanoutconsumer v0.129.0 // indirect
+	go.opentelemetry.io/collector/internal/telemetry v0.129.0 // indirect
+	go.opentelemetry.io/collector/pdata/pprofile v0.129.0 // indirect
+	go.opentelemetry.io/collector/pdata/testdata v0.129.0 // indirect
+	go.opentelemetry.io/collector/pipeline/xpipeline v0.129.0 // indirect
+	go.opentelemetry.io/collector/processor/xprocessor v0.129.0 // indirect
+	go.opentelemetry.io/collector/receiver/xreceiver v0.129.0 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.11.0 // indirect
 	go.opentelemetry.io/otel/log v0.12.2 // indirect
 	go.opentelemetry.io/otel/sdk v1.36.0 // indirect

--- a/cmd/otelcorecol/builder-config.yaml
+++ b/cmd/otelcorecol/builder-config.yaml
@@ -10,24 +10,24 @@ dist:
   module: go.opentelemetry.io/collector/cmd/otelcorecol
   name: otelcorecol
   description: Local OpenTelemetry Collector binary, testing only.
-  version: 0.128.1-dev
+  version: 0.129.0-dev
 
 receivers:
-  - gomod: go.opentelemetry.io/collector/receiver/nopreceiver v0.128.1
-  - gomod: go.opentelemetry.io/collector/receiver/otlpreceiver v0.128.1
+  - gomod: go.opentelemetry.io/collector/receiver/nopreceiver v0.129.0
+  - gomod: go.opentelemetry.io/collector/receiver/otlpreceiver v0.129.0
 exporters:
-  - gomod: go.opentelemetry.io/collector/exporter/debugexporter v0.128.1
-  - gomod: go.opentelemetry.io/collector/exporter/nopexporter v0.128.1
-  - gomod: go.opentelemetry.io/collector/exporter/otlpexporter v0.128.1
-  - gomod: go.opentelemetry.io/collector/exporter/otlphttpexporter v0.128.1
+  - gomod: go.opentelemetry.io/collector/exporter/debugexporter v0.129.0
+  - gomod: go.opentelemetry.io/collector/exporter/nopexporter v0.129.0
+  - gomod: go.opentelemetry.io/collector/exporter/otlpexporter v0.129.0
+  - gomod: go.opentelemetry.io/collector/exporter/otlphttpexporter v0.129.0
 extensions:
-  - gomod: go.opentelemetry.io/collector/extension/memorylimiterextension v0.128.1
-  - gomod: go.opentelemetry.io/collector/extension/zpagesextension v0.128.1
+  - gomod: go.opentelemetry.io/collector/extension/memorylimiterextension v0.129.0
+  - gomod: go.opentelemetry.io/collector/extension/zpagesextension v0.129.0
 processors:
-  - gomod: go.opentelemetry.io/collector/processor/batchprocessor v0.128.1
-  - gomod: go.opentelemetry.io/collector/processor/memorylimiterprocessor v0.128.1
+  - gomod: go.opentelemetry.io/collector/processor/batchprocessor v0.129.0
+  - gomod: go.opentelemetry.io/collector/processor/memorylimiterprocessor v0.129.0
 connectors:
-  - gomod: go.opentelemetry.io/collector/connector/forwardconnector v0.128.1
+  - gomod: go.opentelemetry.io/collector/connector/forwardconnector v0.129.0
 
 providers:
   - gomod: go.opentelemetry.io/collector/confmap/provider/envprovider v1.35.0

--- a/cmd/otelcorecol/builder-config.yaml
+++ b/cmd/otelcorecol/builder-config.yaml
@@ -30,11 +30,11 @@ connectors:
   - gomod: go.opentelemetry.io/collector/connector/forwardconnector v0.128.1
 
 providers:
-  - gomod: go.opentelemetry.io/collector/confmap/provider/envprovider v1.34.1
-  - gomod: go.opentelemetry.io/collector/confmap/provider/fileprovider v1.34.1
-  - gomod: go.opentelemetry.io/collector/confmap/provider/httpprovider v1.34.1
-  - gomod: go.opentelemetry.io/collector/confmap/provider/httpsprovider v1.34.1
-  - gomod: go.opentelemetry.io/collector/confmap/provider/yamlprovider v1.34.1
+  - gomod: go.opentelemetry.io/collector/confmap/provider/envprovider v1.35.0
+  - gomod: go.opentelemetry.io/collector/confmap/provider/fileprovider v1.35.0
+  - gomod: go.opentelemetry.io/collector/confmap/provider/httpprovider v1.35.0
+  - gomod: go.opentelemetry.io/collector/confmap/provider/httpsprovider v1.35.0
+  - gomod: go.opentelemetry.io/collector/confmap/provider/yamlprovider v1.35.0
 
 replaces:
   - go.opentelemetry.io/collector => ../../

--- a/cmd/otelcorecol/components.go
+++ b/cmd/otelcorecol/components.go
@@ -35,8 +35,8 @@ func components() (otelcol.Factories, error) {
 		return otelcol.Factories{}, err
 	}
 	factories.ExtensionModules = make(map[component.Type]string, len(factories.Extensions))
-	factories.ExtensionModules[memorylimiterextension.NewFactory().Type()] = "go.opentelemetry.io/collector/extension/memorylimiterextension v0.128.1"
-	factories.ExtensionModules[zpagesextension.NewFactory().Type()] = "go.opentelemetry.io/collector/extension/zpagesextension v0.128.1"
+	factories.ExtensionModules[memorylimiterextension.NewFactory().Type()] = "go.opentelemetry.io/collector/extension/memorylimiterextension v0.129.0"
+	factories.ExtensionModules[zpagesextension.NewFactory().Type()] = "go.opentelemetry.io/collector/extension/zpagesextension v0.129.0"
 
 	factories.Receivers, err = otelcol.MakeFactoryMap[receiver.Factory](
 		nopreceiver.NewFactory(),
@@ -46,8 +46,8 @@ func components() (otelcol.Factories, error) {
 		return otelcol.Factories{}, err
 	}
 	factories.ReceiverModules = make(map[component.Type]string, len(factories.Receivers))
-	factories.ReceiverModules[nopreceiver.NewFactory().Type()] = "go.opentelemetry.io/collector/receiver/nopreceiver v0.128.1"
-	factories.ReceiverModules[otlpreceiver.NewFactory().Type()] = "go.opentelemetry.io/collector/receiver/otlpreceiver v0.128.1"
+	factories.ReceiverModules[nopreceiver.NewFactory().Type()] = "go.opentelemetry.io/collector/receiver/nopreceiver v0.129.0"
+	factories.ReceiverModules[otlpreceiver.NewFactory().Type()] = "go.opentelemetry.io/collector/receiver/otlpreceiver v0.129.0"
 
 	factories.Exporters, err = otelcol.MakeFactoryMap[exporter.Factory](
 		debugexporter.NewFactory(),
@@ -59,10 +59,10 @@ func components() (otelcol.Factories, error) {
 		return otelcol.Factories{}, err
 	}
 	factories.ExporterModules = make(map[component.Type]string, len(factories.Exporters))
-	factories.ExporterModules[debugexporter.NewFactory().Type()] = "go.opentelemetry.io/collector/exporter/debugexporter v0.128.1"
-	factories.ExporterModules[nopexporter.NewFactory().Type()] = "go.opentelemetry.io/collector/exporter/nopexporter v0.128.1"
-	factories.ExporterModules[otlpexporter.NewFactory().Type()] = "go.opentelemetry.io/collector/exporter/otlpexporter v0.128.1"
-	factories.ExporterModules[otlphttpexporter.NewFactory().Type()] = "go.opentelemetry.io/collector/exporter/otlphttpexporter v0.128.1"
+	factories.ExporterModules[debugexporter.NewFactory().Type()] = "go.opentelemetry.io/collector/exporter/debugexporter v0.129.0"
+	factories.ExporterModules[nopexporter.NewFactory().Type()] = "go.opentelemetry.io/collector/exporter/nopexporter v0.129.0"
+	factories.ExporterModules[otlpexporter.NewFactory().Type()] = "go.opentelemetry.io/collector/exporter/otlpexporter v0.129.0"
+	factories.ExporterModules[otlphttpexporter.NewFactory().Type()] = "go.opentelemetry.io/collector/exporter/otlphttpexporter v0.129.0"
 
 	factories.Processors, err = otelcol.MakeFactoryMap[processor.Factory](
 		batchprocessor.NewFactory(),
@@ -72,8 +72,8 @@ func components() (otelcol.Factories, error) {
 		return otelcol.Factories{}, err
 	}
 	factories.ProcessorModules = make(map[component.Type]string, len(factories.Processors))
-	factories.ProcessorModules[batchprocessor.NewFactory().Type()] = "go.opentelemetry.io/collector/processor/batchprocessor v0.128.1"
-	factories.ProcessorModules[memorylimiterprocessor.NewFactory().Type()] = "go.opentelemetry.io/collector/processor/memorylimiterprocessor v0.128.1"
+	factories.ProcessorModules[batchprocessor.NewFactory().Type()] = "go.opentelemetry.io/collector/processor/batchprocessor v0.129.0"
+	factories.ProcessorModules[memorylimiterprocessor.NewFactory().Type()] = "go.opentelemetry.io/collector/processor/memorylimiterprocessor v0.129.0"
 
 	factories.Connectors, err = otelcol.MakeFactoryMap[connector.Factory](
 		forwardconnector.NewFactory(),
@@ -82,7 +82,7 @@ func components() (otelcol.Factories, error) {
 		return otelcol.Factories{}, err
 	}
 	factories.ConnectorModules = make(map[component.Type]string, len(factories.Connectors))
-	factories.ConnectorModules[forwardconnector.NewFactory().Type()] = "go.opentelemetry.io/collector/connector/forwardconnector v0.128.1"
+	factories.ConnectorModules[forwardconnector.NewFactory().Type()] = "go.opentelemetry.io/collector/connector/forwardconnector v0.129.0"
 
 	return factories, nil
 }

--- a/cmd/otelcorecol/go.mod
+++ b/cmd/otelcorecol/go.mod
@@ -7,13 +7,13 @@ go 1.23.0
 toolchain go1.23.10
 
 require (
-	go.opentelemetry.io/collector/component v1.34.1
-	go.opentelemetry.io/collector/confmap v1.34.1
-	go.opentelemetry.io/collector/confmap/provider/envprovider v1.34.1
-	go.opentelemetry.io/collector/confmap/provider/fileprovider v1.34.1
-	go.opentelemetry.io/collector/confmap/provider/httpprovider v1.34.1
-	go.opentelemetry.io/collector/confmap/provider/httpsprovider v1.34.1
-	go.opentelemetry.io/collector/confmap/provider/yamlprovider v1.34.1
+	go.opentelemetry.io/collector/component v1.35.0
+	go.opentelemetry.io/collector/confmap v1.35.0
+	go.opentelemetry.io/collector/confmap/provider/envprovider v1.35.0
+	go.opentelemetry.io/collector/confmap/provider/fileprovider v1.35.0
+	go.opentelemetry.io/collector/confmap/provider/httpprovider v1.35.0
+	go.opentelemetry.io/collector/confmap/provider/httpsprovider v1.35.0
+	go.opentelemetry.io/collector/confmap/provider/yamlprovider v1.35.0
 	go.opentelemetry.io/collector/connector v0.128.1
 	go.opentelemetry.io/collector/connector/forwardconnector v0.128.1
 	go.opentelemetry.io/collector/exporter v0.128.1
@@ -21,14 +21,14 @@ require (
 	go.opentelemetry.io/collector/exporter/nopexporter v0.128.1
 	go.opentelemetry.io/collector/exporter/otlpexporter v0.128.1
 	go.opentelemetry.io/collector/exporter/otlphttpexporter v0.128.1
-	go.opentelemetry.io/collector/extension v1.34.1
+	go.opentelemetry.io/collector/extension v1.35.0
 	go.opentelemetry.io/collector/extension/memorylimiterextension v0.128.1
 	go.opentelemetry.io/collector/extension/zpagesextension v0.128.1
 	go.opentelemetry.io/collector/otelcol v0.128.1
-	go.opentelemetry.io/collector/processor v1.34.1
+	go.opentelemetry.io/collector/processor v1.35.0
 	go.opentelemetry.io/collector/processor/batchprocessor v0.128.1
 	go.opentelemetry.io/collector/processor/memorylimiterprocessor v0.128.1
-	go.opentelemetry.io/collector/receiver v1.34.1
+	go.opentelemetry.io/collector/receiver v1.35.0
 	go.opentelemetry.io/collector/receiver/nopreceiver v0.128.1
 	go.opentelemetry.io/collector/receiver/otlpreceiver v0.128.1
 	golang.org/x/sys v0.33.0
@@ -84,24 +84,24 @@ require (
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/collector v0.128.1 // indirect
-	go.opentelemetry.io/collector/client v1.34.1 // indirect
+	go.opentelemetry.io/collector/client v1.35.0 // indirect
 	go.opentelemetry.io/collector/component/componentstatus v0.128.1 // indirect
 	go.opentelemetry.io/collector/component/componenttest v0.128.1 // indirect
 	go.opentelemetry.io/collector/config/configauth v0.128.1 // indirect
-	go.opentelemetry.io/collector/config/configcompression v1.34.1 // indirect
+	go.opentelemetry.io/collector/config/configcompression v1.35.0 // indirect
 	go.opentelemetry.io/collector/config/configgrpc v0.128.1 // indirect
 	go.opentelemetry.io/collector/config/confighttp v0.128.1 // indirect
 	go.opentelemetry.io/collector/config/configmiddleware v0.128.1 // indirect
-	go.opentelemetry.io/collector/config/confignet v1.34.1 // indirect
-	go.opentelemetry.io/collector/config/configopaque v1.34.1 // indirect
+	go.opentelemetry.io/collector/config/confignet v1.35.0 // indirect
+	go.opentelemetry.io/collector/config/configopaque v1.35.0 // indirect
 	go.opentelemetry.io/collector/config/configoptional v0.128.1 // indirect
-	go.opentelemetry.io/collector/config/configretry v1.34.1 // indirect
+	go.opentelemetry.io/collector/config/configretry v1.35.0 // indirect
 	go.opentelemetry.io/collector/config/configtelemetry v0.128.1 // indirect
-	go.opentelemetry.io/collector/config/configtls v1.34.1 // indirect
+	go.opentelemetry.io/collector/config/configtls v1.35.0 // indirect
 	go.opentelemetry.io/collector/confmap/xconfmap v0.128.1 // indirect
 	go.opentelemetry.io/collector/connector/connectortest v0.128.1 // indirect
 	go.opentelemetry.io/collector/connector/xconnector v0.128.1 // indirect
-	go.opentelemetry.io/collector/consumer v1.34.1 // indirect
+	go.opentelemetry.io/collector/consumer v1.35.0 // indirect
 	go.opentelemetry.io/collector/consumer/consumererror v0.128.1 // indirect
 	go.opentelemetry.io/collector/consumer/consumererror/xconsumererror v0.128.1 // indirect
 	go.opentelemetry.io/collector/consumer/consumertest v0.128.1 // indirect
@@ -109,17 +109,17 @@ require (
 	go.opentelemetry.io/collector/exporter/exporterhelper/xexporterhelper v0.128.1 // indirect
 	go.opentelemetry.io/collector/exporter/exportertest v0.128.1 // indirect
 	go.opentelemetry.io/collector/exporter/xexporter v0.128.1 // indirect
-	go.opentelemetry.io/collector/extension/extensionauth v1.34.1 // indirect
+	go.opentelemetry.io/collector/extension/extensionauth v1.35.0 // indirect
 	go.opentelemetry.io/collector/extension/extensioncapabilities v0.128.1 // indirect
 	go.opentelemetry.io/collector/extension/extensionmiddleware v0.128.1 // indirect
 	go.opentelemetry.io/collector/extension/extensiontest v0.128.1 // indirect
 	go.opentelemetry.io/collector/extension/xextension v0.128.1 // indirect
-	go.opentelemetry.io/collector/featuregate v1.34.1 // indirect
+	go.opentelemetry.io/collector/featuregate v1.35.0 // indirect
 	go.opentelemetry.io/collector/internal/fanoutconsumer v0.128.1 // indirect
 	go.opentelemetry.io/collector/internal/memorylimiter v0.128.1 // indirect
 	go.opentelemetry.io/collector/internal/sharedcomponent v0.128.1 // indirect
 	go.opentelemetry.io/collector/internal/telemetry v0.128.1 // indirect
-	go.opentelemetry.io/collector/pdata v1.34.1 // indirect
+	go.opentelemetry.io/collector/pdata v1.35.0 // indirect
 	go.opentelemetry.io/collector/pdata/pprofile v0.128.1 // indirect
 	go.opentelemetry.io/collector/pdata/testdata v0.128.1 // indirect
 	go.opentelemetry.io/collector/pdata/xpdata v0.128.1 // indirect

--- a/cmd/otelcorecol/go.mod
+++ b/cmd/otelcorecol/go.mod
@@ -14,23 +14,23 @@ require (
 	go.opentelemetry.io/collector/confmap/provider/httpprovider v1.35.0
 	go.opentelemetry.io/collector/confmap/provider/httpsprovider v1.35.0
 	go.opentelemetry.io/collector/confmap/provider/yamlprovider v1.35.0
-	go.opentelemetry.io/collector/connector v0.128.1
-	go.opentelemetry.io/collector/connector/forwardconnector v0.128.1
-	go.opentelemetry.io/collector/exporter v0.128.1
-	go.opentelemetry.io/collector/exporter/debugexporter v0.128.1
-	go.opentelemetry.io/collector/exporter/nopexporter v0.128.1
-	go.opentelemetry.io/collector/exporter/otlpexporter v0.128.1
-	go.opentelemetry.io/collector/exporter/otlphttpexporter v0.128.1
+	go.opentelemetry.io/collector/connector v0.129.0
+	go.opentelemetry.io/collector/connector/forwardconnector v0.129.0
+	go.opentelemetry.io/collector/exporter v0.129.0
+	go.opentelemetry.io/collector/exporter/debugexporter v0.129.0
+	go.opentelemetry.io/collector/exporter/nopexporter v0.129.0
+	go.opentelemetry.io/collector/exporter/otlpexporter v0.129.0
+	go.opentelemetry.io/collector/exporter/otlphttpexporter v0.129.0
 	go.opentelemetry.io/collector/extension v1.35.0
-	go.opentelemetry.io/collector/extension/memorylimiterextension v0.128.1
-	go.opentelemetry.io/collector/extension/zpagesextension v0.128.1
-	go.opentelemetry.io/collector/otelcol v0.128.1
+	go.opentelemetry.io/collector/extension/memorylimiterextension v0.129.0
+	go.opentelemetry.io/collector/extension/zpagesextension v0.129.0
+	go.opentelemetry.io/collector/otelcol v0.129.0
 	go.opentelemetry.io/collector/processor v1.35.0
-	go.opentelemetry.io/collector/processor/batchprocessor v0.128.1
-	go.opentelemetry.io/collector/processor/memorylimiterprocessor v0.128.1
+	go.opentelemetry.io/collector/processor/batchprocessor v0.129.0
+	go.opentelemetry.io/collector/processor/memorylimiterprocessor v0.129.0
 	go.opentelemetry.io/collector/receiver v1.35.0
-	go.opentelemetry.io/collector/receiver/nopreceiver v0.128.1
-	go.opentelemetry.io/collector/receiver/otlpreceiver v0.128.1
+	go.opentelemetry.io/collector/receiver/nopreceiver v0.129.0
+	go.opentelemetry.io/collector/receiver/otlpreceiver v0.129.0
 	golang.org/x/sys v0.33.0
 )
 
@@ -83,57 +83,57 @@ require (
 	github.com/tklauser/numcpus v0.6.1 // indirect
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
-	go.opentelemetry.io/collector v0.128.1 // indirect
+	go.opentelemetry.io/collector v0.129.0 // indirect
 	go.opentelemetry.io/collector/client v1.35.0 // indirect
-	go.opentelemetry.io/collector/component/componentstatus v0.128.1 // indirect
-	go.opentelemetry.io/collector/component/componenttest v0.128.1 // indirect
-	go.opentelemetry.io/collector/config/configauth v0.128.1 // indirect
+	go.opentelemetry.io/collector/component/componentstatus v0.129.0 // indirect
+	go.opentelemetry.io/collector/component/componenttest v0.129.0 // indirect
+	go.opentelemetry.io/collector/config/configauth v0.129.0 // indirect
 	go.opentelemetry.io/collector/config/configcompression v1.35.0 // indirect
-	go.opentelemetry.io/collector/config/configgrpc v0.128.1 // indirect
-	go.opentelemetry.io/collector/config/confighttp v0.128.1 // indirect
-	go.opentelemetry.io/collector/config/configmiddleware v0.128.1 // indirect
+	go.opentelemetry.io/collector/config/configgrpc v0.129.0 // indirect
+	go.opentelemetry.io/collector/config/confighttp v0.129.0 // indirect
+	go.opentelemetry.io/collector/config/configmiddleware v0.129.0 // indirect
 	go.opentelemetry.io/collector/config/confignet v1.35.0 // indirect
 	go.opentelemetry.io/collector/config/configopaque v1.35.0 // indirect
-	go.opentelemetry.io/collector/config/configoptional v0.128.1 // indirect
+	go.opentelemetry.io/collector/config/configoptional v0.129.0 // indirect
 	go.opentelemetry.io/collector/config/configretry v1.35.0 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.128.1 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.129.0 // indirect
 	go.opentelemetry.io/collector/config/configtls v1.35.0 // indirect
-	go.opentelemetry.io/collector/confmap/xconfmap v0.128.1 // indirect
-	go.opentelemetry.io/collector/connector/connectortest v0.128.1 // indirect
-	go.opentelemetry.io/collector/connector/xconnector v0.128.1 // indirect
+	go.opentelemetry.io/collector/confmap/xconfmap v0.129.0 // indirect
+	go.opentelemetry.io/collector/connector/connectortest v0.129.0 // indirect
+	go.opentelemetry.io/collector/connector/xconnector v0.129.0 // indirect
 	go.opentelemetry.io/collector/consumer v1.35.0 // indirect
-	go.opentelemetry.io/collector/consumer/consumererror v0.128.1 // indirect
-	go.opentelemetry.io/collector/consumer/consumererror/xconsumererror v0.128.1 // indirect
-	go.opentelemetry.io/collector/consumer/consumertest v0.128.1 // indirect
-	go.opentelemetry.io/collector/consumer/xconsumer v0.128.1 // indirect
-	go.opentelemetry.io/collector/exporter/exporterhelper/xexporterhelper v0.128.1 // indirect
-	go.opentelemetry.io/collector/exporter/exportertest v0.128.1 // indirect
-	go.opentelemetry.io/collector/exporter/xexporter v0.128.1 // indirect
+	go.opentelemetry.io/collector/consumer/consumererror v0.129.0 // indirect
+	go.opentelemetry.io/collector/consumer/consumererror/xconsumererror v0.129.0 // indirect
+	go.opentelemetry.io/collector/consumer/consumertest v0.129.0 // indirect
+	go.opentelemetry.io/collector/consumer/xconsumer v0.129.0 // indirect
+	go.opentelemetry.io/collector/exporter/exporterhelper/xexporterhelper v0.129.0 // indirect
+	go.opentelemetry.io/collector/exporter/exportertest v0.129.0 // indirect
+	go.opentelemetry.io/collector/exporter/xexporter v0.129.0 // indirect
 	go.opentelemetry.io/collector/extension/extensionauth v1.35.0 // indirect
-	go.opentelemetry.io/collector/extension/extensioncapabilities v0.128.1 // indirect
-	go.opentelemetry.io/collector/extension/extensionmiddleware v0.128.1 // indirect
-	go.opentelemetry.io/collector/extension/extensiontest v0.128.1 // indirect
-	go.opentelemetry.io/collector/extension/xextension v0.128.1 // indirect
+	go.opentelemetry.io/collector/extension/extensioncapabilities v0.129.0 // indirect
+	go.opentelemetry.io/collector/extension/extensionmiddleware v0.129.0 // indirect
+	go.opentelemetry.io/collector/extension/extensiontest v0.129.0 // indirect
+	go.opentelemetry.io/collector/extension/xextension v0.129.0 // indirect
 	go.opentelemetry.io/collector/featuregate v1.35.0 // indirect
-	go.opentelemetry.io/collector/internal/fanoutconsumer v0.128.1 // indirect
-	go.opentelemetry.io/collector/internal/memorylimiter v0.128.1 // indirect
-	go.opentelemetry.io/collector/internal/sharedcomponent v0.128.1 // indirect
-	go.opentelemetry.io/collector/internal/telemetry v0.128.1 // indirect
+	go.opentelemetry.io/collector/internal/fanoutconsumer v0.129.0 // indirect
+	go.opentelemetry.io/collector/internal/memorylimiter v0.129.0 // indirect
+	go.opentelemetry.io/collector/internal/sharedcomponent v0.129.0 // indirect
+	go.opentelemetry.io/collector/internal/telemetry v0.129.0 // indirect
 	go.opentelemetry.io/collector/pdata v1.35.0 // indirect
-	go.opentelemetry.io/collector/pdata/pprofile v0.128.1 // indirect
-	go.opentelemetry.io/collector/pdata/testdata v0.128.1 // indirect
-	go.opentelemetry.io/collector/pdata/xpdata v0.128.1 // indirect
-	go.opentelemetry.io/collector/pipeline v0.128.1 // indirect
-	go.opentelemetry.io/collector/pipeline/xpipeline v0.128.1 // indirect
-	go.opentelemetry.io/collector/processor/processorhelper v0.128.1 // indirect
-	go.opentelemetry.io/collector/processor/processorhelper/xprocessorhelper v0.128.1 // indirect
-	go.opentelemetry.io/collector/processor/processortest v0.128.1 // indirect
-	go.opentelemetry.io/collector/processor/xprocessor v0.128.1 // indirect
-	go.opentelemetry.io/collector/receiver/receiverhelper v0.128.1 // indirect
-	go.opentelemetry.io/collector/receiver/receivertest v0.128.1 // indirect
-	go.opentelemetry.io/collector/receiver/xreceiver v0.128.1 // indirect
-	go.opentelemetry.io/collector/service v0.128.1 // indirect
-	go.opentelemetry.io/collector/service/hostcapabilities v0.128.1 // indirect
+	go.opentelemetry.io/collector/pdata/pprofile v0.129.0 // indirect
+	go.opentelemetry.io/collector/pdata/testdata v0.129.0 // indirect
+	go.opentelemetry.io/collector/pdata/xpdata v0.129.0 // indirect
+	go.opentelemetry.io/collector/pipeline v0.129.0 // indirect
+	go.opentelemetry.io/collector/pipeline/xpipeline v0.129.0 // indirect
+	go.opentelemetry.io/collector/processor/processorhelper v0.129.0 // indirect
+	go.opentelemetry.io/collector/processor/processorhelper/xprocessorhelper v0.129.0 // indirect
+	go.opentelemetry.io/collector/processor/processortest v0.129.0 // indirect
+	go.opentelemetry.io/collector/processor/xprocessor v0.129.0 // indirect
+	go.opentelemetry.io/collector/receiver/receiverhelper v0.129.0 // indirect
+	go.opentelemetry.io/collector/receiver/receivertest v0.129.0 // indirect
+	go.opentelemetry.io/collector/receiver/xreceiver v0.129.0 // indirect
+	go.opentelemetry.io/collector/service v0.129.0 // indirect
+	go.opentelemetry.io/collector/service/hostcapabilities v0.129.0 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.11.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.61.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.61.0 // indirect

--- a/cmd/otelcorecol/main.go
+++ b/cmd/otelcorecol/main.go
@@ -20,7 +20,7 @@ func main() {
 	info := component.BuildInfo{
 		Command:     "otelcorecol",
 		Description: "Local OpenTelemetry Collector binary, testing only.",
-		Version:     "0.128.1-dev",
+		Version:     "0.129.0-dev",
 	}
 
 	set := otelcol.CollectorSettings{

--- a/cmd/otelcorecol/main.go
+++ b/cmd/otelcorecol/main.go
@@ -38,11 +38,11 @@ func main() {
 			},
 		},
 		ProviderModules: map[string]string{
-			envprovider.NewFactory().Create(confmap.ProviderSettings{}).Scheme():   "go.opentelemetry.io/collector/confmap/provider/envprovider v1.34.1",
-			fileprovider.NewFactory().Create(confmap.ProviderSettings{}).Scheme():  "go.opentelemetry.io/collector/confmap/provider/fileprovider v1.34.1",
-			httpprovider.NewFactory().Create(confmap.ProviderSettings{}).Scheme():  "go.opentelemetry.io/collector/confmap/provider/httpprovider v1.34.1",
-			httpsprovider.NewFactory().Create(confmap.ProviderSettings{}).Scheme(): "go.opentelemetry.io/collector/confmap/provider/httpsprovider v1.34.1",
-			yamlprovider.NewFactory().Create(confmap.ProviderSettings{}).Scheme():  "go.opentelemetry.io/collector/confmap/provider/yamlprovider v1.34.1",
+			envprovider.NewFactory().Create(confmap.ProviderSettings{}).Scheme():   "go.opentelemetry.io/collector/confmap/provider/envprovider v1.35.0",
+			fileprovider.NewFactory().Create(confmap.ProviderSettings{}).Scheme():  "go.opentelemetry.io/collector/confmap/provider/fileprovider v1.35.0",
+			httpprovider.NewFactory().Create(confmap.ProviderSettings{}).Scheme():  "go.opentelemetry.io/collector/confmap/provider/httpprovider v1.35.0",
+			httpsprovider.NewFactory().Create(confmap.ProviderSettings{}).Scheme(): "go.opentelemetry.io/collector/confmap/provider/httpsprovider v1.35.0",
+			yamlprovider.NewFactory().Create(confmap.ProviderSettings{}).Scheme():  "go.opentelemetry.io/collector/confmap/provider/yamlprovider v1.35.0",
 		},
 		ConverterModules: []string{},
 	}

--- a/component/componentstatus/go.mod
+++ b/component/componentstatus/go.mod
@@ -4,7 +4,7 @@ go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0
-	go.opentelemetry.io/collector/component v1.34.1
+	go.opentelemetry.io/collector/component v1.35.0
 	go.opentelemetry.io/collector/pipeline v0.128.1
 )
 
@@ -17,9 +17,9 @@ require (
 	github.com/hashicorp/go-version v1.7.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
-	go.opentelemetry.io/collector/featuregate v1.34.1 // indirect
+	go.opentelemetry.io/collector/featuregate v1.35.0 // indirect
 	go.opentelemetry.io/collector/internal/telemetry v0.128.1 // indirect
-	go.opentelemetry.io/collector/pdata v1.34.1 // indirect
+	go.opentelemetry.io/collector/pdata v1.35.0 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.11.0 // indirect
 	go.opentelemetry.io/otel v1.36.0 // indirect
 	go.opentelemetry.io/otel/log v0.12.2 // indirect

--- a/component/componentstatus/go.mod
+++ b/component/componentstatus/go.mod
@@ -5,7 +5,7 @@ go 1.23.0
 require (
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/component v1.35.0
-	go.opentelemetry.io/collector/pipeline v0.128.1
+	go.opentelemetry.io/collector/pipeline v0.129.0
 )
 
 require (
@@ -18,7 +18,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/collector/featuregate v1.35.0 // indirect
-	go.opentelemetry.io/collector/internal/telemetry v0.128.1 // indirect
+	go.opentelemetry.io/collector/internal/telemetry v0.129.0 // indirect
 	go.opentelemetry.io/collector/pdata v1.35.0 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.11.0 // indirect
 	go.opentelemetry.io/otel v1.36.0 // indirect

--- a/component/componenttest/go.mod
+++ b/component/componenttest/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/collector/featuregate v1.35.0 // indirect
-	go.opentelemetry.io/collector/internal/telemetry v0.128.1 // indirect
+	go.opentelemetry.io/collector/internal/telemetry v0.129.0 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.11.0 // indirect
 	go.opentelemetry.io/otel v1.36.0 // indirect
 	go.opentelemetry.io/otel/log v0.12.2 // indirect

--- a/component/componenttest/go.mod
+++ b/component/componenttest/go.mod
@@ -4,8 +4,8 @@ go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0
-	go.opentelemetry.io/collector/component v1.34.1
-	go.opentelemetry.io/collector/pdata v1.34.1
+	go.opentelemetry.io/collector/component v1.35.0
+	go.opentelemetry.io/collector/pdata v1.35.0
 	go.opentelemetry.io/otel/metric v1.36.0
 	go.opentelemetry.io/otel/sdk v1.36.0
 	go.opentelemetry.io/otel/sdk/metric v1.36.0
@@ -24,7 +24,7 @@ require (
 	github.com/hashicorp/go-version v1.7.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
-	go.opentelemetry.io/collector/featuregate v1.34.1 // indirect
+	go.opentelemetry.io/collector/featuregate v1.35.0 // indirect
 	go.opentelemetry.io/collector/internal/telemetry v0.128.1 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.11.0 // indirect
 	go.opentelemetry.io/otel v1.36.0 // indirect

--- a/component/go.mod
+++ b/component/go.mod
@@ -4,7 +4,7 @@ go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0
-	go.opentelemetry.io/collector/internal/telemetry v0.128.1
+	go.opentelemetry.io/collector/internal/telemetry v0.129.0
 	go.uber.org/goleak v1.3.0
 )
 

--- a/component/go.mod
+++ b/component/go.mod
@@ -17,8 +17,8 @@ require (
 	github.com/hashicorp/go-version v1.7.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
-	go.opentelemetry.io/collector/featuregate v1.34.1 // indirect
-	go.opentelemetry.io/collector/pdata v1.34.1 // indirect
+	go.opentelemetry.io/collector/featuregate v1.35.0 // indirect
+	go.opentelemetry.io/collector/pdata v1.35.0 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.11.0 // indirect
 	go.opentelemetry.io/otel v1.36.0 // indirect
 	go.opentelemetry.io/otel/log v0.12.2 // indirect

--- a/config/configauth/go.mod
+++ b/config/configauth/go.mod
@@ -7,7 +7,7 @@ require (
 	go.opentelemetry.io/collector/component v1.35.0
 	go.opentelemetry.io/collector/extension v1.35.0
 	go.opentelemetry.io/collector/extension/extensionauth v1.35.0
-	go.opentelemetry.io/collector/extension/extensionauth/extensionauthtest v0.128.1
+	go.opentelemetry.io/collector/extension/extensionauth/extensionauthtest v0.129.0
 	go.uber.org/goleak v1.3.0
 )
 
@@ -21,7 +21,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/collector/featuregate v1.35.0 // indirect
-	go.opentelemetry.io/collector/internal/telemetry v0.128.1 // indirect
+	go.opentelemetry.io/collector/internal/telemetry v0.129.0 // indirect
 	go.opentelemetry.io/collector/pdata v1.35.0 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.11.0 // indirect
 	go.opentelemetry.io/otel v1.36.0 // indirect

--- a/config/configauth/go.mod
+++ b/config/configauth/go.mod
@@ -4,9 +4,9 @@ go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0
-	go.opentelemetry.io/collector/component v1.34.1
-	go.opentelemetry.io/collector/extension v1.34.1
-	go.opentelemetry.io/collector/extension/extensionauth v1.34.1
+	go.opentelemetry.io/collector/component v1.35.0
+	go.opentelemetry.io/collector/extension v1.35.0
+	go.opentelemetry.io/collector/extension/extensionauth v1.35.0
 	go.opentelemetry.io/collector/extension/extensionauth/extensionauthtest v0.128.1
 	go.uber.org/goleak v1.3.0
 )
@@ -20,9 +20,9 @@ require (
 	github.com/hashicorp/go-version v1.7.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
-	go.opentelemetry.io/collector/featuregate v1.34.1 // indirect
+	go.opentelemetry.io/collector/featuregate v1.35.0 // indirect
 	go.opentelemetry.io/collector/internal/telemetry v0.128.1 // indirect
-	go.opentelemetry.io/collector/pdata v1.34.1 // indirect
+	go.opentelemetry.io/collector/pdata v1.35.0 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.11.0 // indirect
 	go.opentelemetry.io/otel v1.36.0 // indirect
 	go.opentelemetry.io/otel/log v0.12.2 // indirect

--- a/config/configgrpc/go.mod
+++ b/config/configgrpc/go.mod
@@ -5,21 +5,21 @@ go 1.23.0
 require (
 	github.com/mostynb/go-grpc-compression v1.2.3
 	github.com/stretchr/testify v1.10.0
-	go.opentelemetry.io/collector/client v1.34.1
-	go.opentelemetry.io/collector/component v1.34.1
+	go.opentelemetry.io/collector/client v1.35.0
+	go.opentelemetry.io/collector/component v1.35.0
 	go.opentelemetry.io/collector/component/componenttest v0.128.1
 	go.opentelemetry.io/collector/config/configauth v0.128.1
-	go.opentelemetry.io/collector/config/configcompression v1.34.1
+	go.opentelemetry.io/collector/config/configcompression v1.35.0
 	go.opentelemetry.io/collector/config/configmiddleware v0.128.1
-	go.opentelemetry.io/collector/config/confignet v1.34.1
-	go.opentelemetry.io/collector/config/configopaque v1.34.1
-	go.opentelemetry.io/collector/config/configtls v1.34.1
-	go.opentelemetry.io/collector/extension v1.34.1
-	go.opentelemetry.io/collector/extension/extensionauth v1.34.1
+	go.opentelemetry.io/collector/config/confignet v1.35.0
+	go.opentelemetry.io/collector/config/configopaque v1.35.0
+	go.opentelemetry.io/collector/config/configtls v1.35.0
+	go.opentelemetry.io/collector/extension v1.35.0
+	go.opentelemetry.io/collector/extension/extensionauth v1.35.0
 	go.opentelemetry.io/collector/extension/extensionauth/extensionauthtest v0.128.1
 	go.opentelemetry.io/collector/extension/extensionmiddleware v0.128.1
 	go.opentelemetry.io/collector/extension/extensionmiddleware/extensionmiddlewaretest v0.128.1
-	go.opentelemetry.io/collector/pdata v1.34.1
+	go.opentelemetry.io/collector/pdata v1.35.0
 	go.opentelemetry.io/collector/pdata/testdata v0.128.1
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.61.0
 	go.opentelemetry.io/otel v1.36.0
@@ -44,7 +44,7 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
-	go.opentelemetry.io/collector/featuregate v1.34.1 // indirect
+	go.opentelemetry.io/collector/featuregate v1.35.0 // indirect
 	go.opentelemetry.io/collector/internal/telemetry v0.128.1 // indirect
 	go.opentelemetry.io/collector/pdata/pprofile v0.128.1 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.11.0 // indirect

--- a/config/configgrpc/go.mod
+++ b/config/configgrpc/go.mod
@@ -7,20 +7,20 @@ require (
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/client v1.35.0
 	go.opentelemetry.io/collector/component v1.35.0
-	go.opentelemetry.io/collector/component/componenttest v0.128.1
-	go.opentelemetry.io/collector/config/configauth v0.128.1
+	go.opentelemetry.io/collector/component/componenttest v0.129.0
+	go.opentelemetry.io/collector/config/configauth v0.129.0
 	go.opentelemetry.io/collector/config/configcompression v1.35.0
-	go.opentelemetry.io/collector/config/configmiddleware v0.128.1
+	go.opentelemetry.io/collector/config/configmiddleware v0.129.0
 	go.opentelemetry.io/collector/config/confignet v1.35.0
 	go.opentelemetry.io/collector/config/configopaque v1.35.0
 	go.opentelemetry.io/collector/config/configtls v1.35.0
 	go.opentelemetry.io/collector/extension v1.35.0
 	go.opentelemetry.io/collector/extension/extensionauth v1.35.0
-	go.opentelemetry.io/collector/extension/extensionauth/extensionauthtest v0.128.1
-	go.opentelemetry.io/collector/extension/extensionmiddleware v0.128.1
-	go.opentelemetry.io/collector/extension/extensionmiddleware/extensionmiddlewaretest v0.128.1
+	go.opentelemetry.io/collector/extension/extensionauth/extensionauthtest v0.129.0
+	go.opentelemetry.io/collector/extension/extensionmiddleware v0.129.0
+	go.opentelemetry.io/collector/extension/extensionmiddleware/extensionmiddlewaretest v0.129.0
 	go.opentelemetry.io/collector/pdata v1.35.0
-	go.opentelemetry.io/collector/pdata/testdata v0.128.1
+	go.opentelemetry.io/collector/pdata/testdata v0.129.0
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.61.0
 	go.opentelemetry.io/otel v1.36.0
 	go.uber.org/goleak v1.3.0
@@ -45,8 +45,8 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/collector/featuregate v1.35.0 // indirect
-	go.opentelemetry.io/collector/internal/telemetry v0.128.1 // indirect
-	go.opentelemetry.io/collector/pdata/pprofile v0.128.1 // indirect
+	go.opentelemetry.io/collector/internal/telemetry v0.129.0 // indirect
+	go.opentelemetry.io/collector/pdata/pprofile v0.129.0 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.11.0 // indirect
 	go.opentelemetry.io/otel/log v0.12.2 // indirect
 	go.opentelemetry.io/otel/metric v1.36.0 // indirect

--- a/config/confighttp/go.mod
+++ b/config/confighttp/go.mod
@@ -8,20 +8,20 @@ require (
 	github.com/pierrec/lz4/v4 v4.1.22
 	github.com/rs/cors v1.11.1
 	github.com/stretchr/testify v1.10.0
-	go.opentelemetry.io/collector/client v1.34.1
-	go.opentelemetry.io/collector/component v1.34.1
+	go.opentelemetry.io/collector/client v1.35.0
+	go.opentelemetry.io/collector/component v1.35.0
 	go.opentelemetry.io/collector/component/componenttest v0.128.1
 	go.opentelemetry.io/collector/config/configauth v0.128.1
-	go.opentelemetry.io/collector/config/configcompression v1.34.1
+	go.opentelemetry.io/collector/config/configcompression v1.35.0
 	go.opentelemetry.io/collector/config/configmiddleware v0.128.1
-	go.opentelemetry.io/collector/config/configopaque v1.34.1
-	go.opentelemetry.io/collector/config/configtls v1.34.1
-	go.opentelemetry.io/collector/extension v1.34.1
-	go.opentelemetry.io/collector/extension/extensionauth v1.34.1
+	go.opentelemetry.io/collector/config/configopaque v1.35.0
+	go.opentelemetry.io/collector/config/configtls v1.35.0
+	go.opentelemetry.io/collector/extension v1.35.0
+	go.opentelemetry.io/collector/extension/extensionauth v1.35.0
 	go.opentelemetry.io/collector/extension/extensionauth/extensionauthtest v0.128.1
 	go.opentelemetry.io/collector/extension/extensionmiddleware v0.128.1
 	go.opentelemetry.io/collector/extension/extensionmiddleware/extensionmiddlewaretest v0.128.1
-	go.opentelemetry.io/collector/featuregate v1.34.1
+	go.opentelemetry.io/collector/featuregate v1.35.0
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.61.0
 	go.opentelemetry.io/otel v1.36.0
 	go.uber.org/goleak v1.3.0
@@ -43,7 +43,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/collector/internal/telemetry v0.128.1 // indirect
-	go.opentelemetry.io/collector/pdata v1.34.1 // indirect
+	go.opentelemetry.io/collector/pdata v1.35.0 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.11.0 // indirect
 	go.opentelemetry.io/otel/log v0.12.2 // indirect
 	go.opentelemetry.io/otel/metric v1.36.0 // indirect

--- a/config/confighttp/go.mod
+++ b/config/confighttp/go.mod
@@ -10,17 +10,17 @@ require (
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/client v1.35.0
 	go.opentelemetry.io/collector/component v1.35.0
-	go.opentelemetry.io/collector/component/componenttest v0.128.1
-	go.opentelemetry.io/collector/config/configauth v0.128.1
+	go.opentelemetry.io/collector/component/componenttest v0.129.0
+	go.opentelemetry.io/collector/config/configauth v0.129.0
 	go.opentelemetry.io/collector/config/configcompression v1.35.0
-	go.opentelemetry.io/collector/config/configmiddleware v0.128.1
+	go.opentelemetry.io/collector/config/configmiddleware v0.129.0
 	go.opentelemetry.io/collector/config/configopaque v1.35.0
 	go.opentelemetry.io/collector/config/configtls v1.35.0
 	go.opentelemetry.io/collector/extension v1.35.0
 	go.opentelemetry.io/collector/extension/extensionauth v1.35.0
-	go.opentelemetry.io/collector/extension/extensionauth/extensionauthtest v0.128.1
-	go.opentelemetry.io/collector/extension/extensionmiddleware v0.128.1
-	go.opentelemetry.io/collector/extension/extensionmiddleware/extensionmiddlewaretest v0.128.1
+	go.opentelemetry.io/collector/extension/extensionauth/extensionauthtest v0.129.0
+	go.opentelemetry.io/collector/extension/extensionmiddleware v0.129.0
+	go.opentelemetry.io/collector/extension/extensionmiddleware/extensionmiddlewaretest v0.129.0
 	go.opentelemetry.io/collector/featuregate v1.35.0
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.61.0
 	go.opentelemetry.io/otel v1.36.0
@@ -42,7 +42,7 @@ require (
 	github.com/hashicorp/go-version v1.7.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
-	go.opentelemetry.io/collector/internal/telemetry v0.128.1 // indirect
+	go.opentelemetry.io/collector/internal/telemetry v0.129.0 // indirect
 	go.opentelemetry.io/collector/pdata v1.35.0 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.11.0 // indirect
 	go.opentelemetry.io/otel/log v0.12.2 // indirect

--- a/config/confighttp/xconfighttp/go.mod
+++ b/config/confighttp/xconfighttp/go.mod
@@ -4,8 +4,8 @@ go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0
-	go.opentelemetry.io/collector/component/componenttest v0.128.1
-	go.opentelemetry.io/collector/config/confighttp v0.128.1
+	go.opentelemetry.io/collector/component/componenttest v0.129.0
+	go.opentelemetry.io/collector/config/confighttp v0.129.0
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.61.0
 	go.opentelemetry.io/otel/sdk v1.36.0
 	go.opentelemetry.io/otel/trace v1.36.0
@@ -30,15 +30,15 @@ require (
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/collector/client v1.35.0 // indirect
 	go.opentelemetry.io/collector/component v1.35.0 // indirect
-	go.opentelemetry.io/collector/config/configauth v0.128.1 // indirect
+	go.opentelemetry.io/collector/config/configauth v0.129.0 // indirect
 	go.opentelemetry.io/collector/config/configcompression v1.35.0 // indirect
-	go.opentelemetry.io/collector/config/configmiddleware v0.128.1 // indirect
+	go.opentelemetry.io/collector/config/configmiddleware v0.129.0 // indirect
 	go.opentelemetry.io/collector/config/configopaque v1.35.0 // indirect
 	go.opentelemetry.io/collector/config/configtls v1.35.0 // indirect
 	go.opentelemetry.io/collector/extension/extensionauth v1.35.0 // indirect
-	go.opentelemetry.io/collector/extension/extensionmiddleware v0.128.1 // indirect
+	go.opentelemetry.io/collector/extension/extensionmiddleware v0.129.0 // indirect
 	go.opentelemetry.io/collector/featuregate v1.35.0 // indirect
-	go.opentelemetry.io/collector/internal/telemetry v0.128.1 // indirect
+	go.opentelemetry.io/collector/internal/telemetry v0.129.0 // indirect
 	go.opentelemetry.io/collector/pdata v1.35.0 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.11.0 // indirect
 	go.opentelemetry.io/otel v1.36.0 // indirect

--- a/config/confighttp/xconfighttp/go.mod
+++ b/config/confighttp/xconfighttp/go.mod
@@ -28,18 +28,18 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rs/cors v1.11.1 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
-	go.opentelemetry.io/collector/client v1.34.1 // indirect
-	go.opentelemetry.io/collector/component v1.34.1 // indirect
+	go.opentelemetry.io/collector/client v1.35.0 // indirect
+	go.opentelemetry.io/collector/component v1.35.0 // indirect
 	go.opentelemetry.io/collector/config/configauth v0.128.1 // indirect
-	go.opentelemetry.io/collector/config/configcompression v1.34.1 // indirect
+	go.opentelemetry.io/collector/config/configcompression v1.35.0 // indirect
 	go.opentelemetry.io/collector/config/configmiddleware v0.128.1 // indirect
-	go.opentelemetry.io/collector/config/configopaque v1.34.1 // indirect
-	go.opentelemetry.io/collector/config/configtls v1.34.1 // indirect
-	go.opentelemetry.io/collector/extension/extensionauth v1.34.1 // indirect
+	go.opentelemetry.io/collector/config/configopaque v1.35.0 // indirect
+	go.opentelemetry.io/collector/config/configtls v1.35.0 // indirect
+	go.opentelemetry.io/collector/extension/extensionauth v1.35.0 // indirect
 	go.opentelemetry.io/collector/extension/extensionmiddleware v0.128.1 // indirect
-	go.opentelemetry.io/collector/featuregate v1.34.1 // indirect
+	go.opentelemetry.io/collector/featuregate v1.35.0 // indirect
 	go.opentelemetry.io/collector/internal/telemetry v0.128.1 // indirect
-	go.opentelemetry.io/collector/pdata v1.34.1 // indirect
+	go.opentelemetry.io/collector/pdata v1.35.0 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.11.0 // indirect
 	go.opentelemetry.io/otel v1.36.0 // indirect
 	go.opentelemetry.io/otel/log v0.12.2 // indirect

--- a/config/configmiddleware/go.mod
+++ b/config/configmiddleware/go.mod
@@ -4,8 +4,8 @@ go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0
-	go.opentelemetry.io/collector/component v1.34.1
-	go.opentelemetry.io/collector/extension v1.34.1
+	go.opentelemetry.io/collector/component v1.35.0
+	go.opentelemetry.io/collector/extension v1.35.0
 	go.opentelemetry.io/collector/extension/extensionmiddleware v0.128.1
 	go.opentelemetry.io/collector/extension/extensionmiddleware/extensionmiddlewaretest v0.128.1
 	google.golang.org/grpc v1.73.0
@@ -20,9 +20,9 @@ require (
 	github.com/hashicorp/go-version v1.7.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
-	go.opentelemetry.io/collector/featuregate v1.34.1 // indirect
+	go.opentelemetry.io/collector/featuregate v1.35.0 // indirect
 	go.opentelemetry.io/collector/internal/telemetry v0.128.1 // indirect
-	go.opentelemetry.io/collector/pdata v1.34.1 // indirect
+	go.opentelemetry.io/collector/pdata v1.35.0 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.11.0 // indirect
 	go.opentelemetry.io/otel v1.36.0 // indirect
 	go.opentelemetry.io/otel/log v0.12.2 // indirect

--- a/config/configmiddleware/go.mod
+++ b/config/configmiddleware/go.mod
@@ -6,8 +6,8 @@ require (
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/component v1.35.0
 	go.opentelemetry.io/collector/extension v1.35.0
-	go.opentelemetry.io/collector/extension/extensionmiddleware v0.128.1
-	go.opentelemetry.io/collector/extension/extensionmiddleware/extensionmiddlewaretest v0.128.1
+	go.opentelemetry.io/collector/extension/extensionmiddleware v0.129.0
+	go.opentelemetry.io/collector/extension/extensionmiddleware/extensionmiddlewaretest v0.129.0
 	google.golang.org/grpc v1.73.0
 )
 
@@ -21,7 +21,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/collector/featuregate v1.35.0 // indirect
-	go.opentelemetry.io/collector/internal/telemetry v0.128.1 // indirect
+	go.opentelemetry.io/collector/internal/telemetry v0.129.0 // indirect
 	go.opentelemetry.io/collector/pdata v1.35.0 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.11.0 // indirect
 	go.opentelemetry.io/otel v1.36.0 // indirect

--- a/config/configoptional/go.mod
+++ b/config/configoptional/go.mod
@@ -4,7 +4,7 @@ go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0
-	go.opentelemetry.io/collector/confmap v1.34.1
+	go.opentelemetry.io/collector/confmap v1.35.0
 	go.uber.org/goleak v1.3.0
 )
 
@@ -19,7 +19,7 @@ require (
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	go.opentelemetry.io/collector/featuregate v1.34.1 // indirect
+	go.opentelemetry.io/collector/featuregate v1.35.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.27.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/config/configtls/go.mod
+++ b/config/configtls/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/fsnotify/fsnotify v1.9.0
 	github.com/google/go-tpm v0.9.5
 	github.com/stretchr/testify v1.10.0
-	go.opentelemetry.io/collector/config/configopaque v1.34.1
+	go.opentelemetry.io/collector/config/configopaque v1.35.0
 )
 
 require (

--- a/confmap/go.mod
+++ b/confmap/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/knadh/koanf/providers/confmap v1.0.0
 	github.com/knadh/koanf/v2 v2.2.1
 	github.com/stretchr/testify v1.10.0
-	go.opentelemetry.io/collector/featuregate v1.34.1
+	go.opentelemetry.io/collector/featuregate v1.35.0
 	go.uber.org/goleak v1.3.0
 	go.uber.org/multierr v1.11.0
 	go.uber.org/zap v1.27.0

--- a/confmap/internal/e2e/go.mod
+++ b/confmap/internal/e2e/go.mod
@@ -4,10 +4,10 @@ go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0
-	go.opentelemetry.io/collector/config/configopaque v1.34.1
-	go.opentelemetry.io/collector/confmap v1.34.1
-	go.opentelemetry.io/collector/confmap/provider/envprovider v1.34.1
-	go.opentelemetry.io/collector/confmap/provider/fileprovider v1.34.1
+	go.opentelemetry.io/collector/config/configopaque v1.35.0
+	go.opentelemetry.io/collector/confmap v1.35.0
+	go.opentelemetry.io/collector/confmap/provider/envprovider v1.35.0
+	go.opentelemetry.io/collector/confmap/provider/fileprovider v1.35.0
 )
 
 require (
@@ -21,7 +21,7 @@ require (
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	go.opentelemetry.io/collector/featuregate v1.34.1 // indirect
+	go.opentelemetry.io/collector/featuregate v1.35.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.27.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/confmap/provider/envprovider/go.mod
+++ b/confmap/provider/envprovider/go.mod
@@ -4,7 +4,7 @@ go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0
-	go.opentelemetry.io/collector/confmap v1.34.1
+	go.opentelemetry.io/collector/confmap v1.35.0
 	go.uber.org/goleak v1.3.0
 	go.uber.org/zap v1.27.0
 )
@@ -20,7 +20,7 @@ require (
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	go.opentelemetry.io/collector/featuregate v1.34.1 // indirect
+	go.opentelemetry.io/collector/featuregate v1.35.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	sigs.k8s.io/yaml v1.4.0 // indirect

--- a/confmap/provider/fileprovider/go.mod
+++ b/confmap/provider/fileprovider/go.mod
@@ -4,7 +4,7 @@ go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0
-	go.opentelemetry.io/collector/confmap v1.34.1
+	go.opentelemetry.io/collector/confmap v1.35.0
 	go.uber.org/goleak v1.3.0
 )
 
@@ -19,7 +19,7 @@ require (
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	go.opentelemetry.io/collector/featuregate v1.34.1 // indirect
+	go.opentelemetry.io/collector/featuregate v1.35.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.27.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/confmap/provider/httpprovider/go.mod
+++ b/confmap/provider/httpprovider/go.mod
@@ -4,7 +4,7 @@ go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0
-	go.opentelemetry.io/collector/confmap v1.34.1
+	go.opentelemetry.io/collector/confmap v1.35.0
 	go.uber.org/goleak v1.3.0
 )
 
@@ -19,7 +19,7 @@ require (
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	go.opentelemetry.io/collector/featuregate v1.34.1 // indirect
+	go.opentelemetry.io/collector/featuregate v1.35.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.27.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/confmap/provider/httpsprovider/go.mod
+++ b/confmap/provider/httpsprovider/go.mod
@@ -4,7 +4,7 @@ go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0
-	go.opentelemetry.io/collector/confmap v1.34.1
+	go.opentelemetry.io/collector/confmap v1.35.0
 	go.uber.org/goleak v1.3.0
 )
 
@@ -19,7 +19,7 @@ require (
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	go.opentelemetry.io/collector/featuregate v1.34.1 // indirect
+	go.opentelemetry.io/collector/featuregate v1.35.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.27.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/confmap/provider/yamlprovider/go.mod
+++ b/confmap/provider/yamlprovider/go.mod
@@ -4,7 +4,7 @@ go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0
-	go.opentelemetry.io/collector/confmap v1.34.1
+	go.opentelemetry.io/collector/confmap v1.35.0
 	go.uber.org/goleak v1.3.0
 )
 
@@ -19,7 +19,7 @@ require (
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	go.opentelemetry.io/collector/featuregate v1.34.1 // indirect
+	go.opentelemetry.io/collector/featuregate v1.35.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.27.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/confmap/xconfmap/go.mod
+++ b/confmap/xconfmap/go.mod
@@ -4,7 +4,7 @@ go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0
-	go.opentelemetry.io/collector/confmap v1.34.1
+	go.opentelemetry.io/collector/confmap v1.35.0
 )
 
 require (
@@ -18,7 +18,7 @@ require (
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	go.opentelemetry.io/collector/featuregate v1.34.1 // indirect
+	go.opentelemetry.io/collector/featuregate v1.35.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.27.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/connector/connectortest/go.mod
+++ b/connector/connectortest/go.mod
@@ -5,14 +5,14 @@ go 1.23.0
 require (
 	github.com/google/uuid v1.6.0
 	github.com/stretchr/testify v1.10.0
-	go.opentelemetry.io/collector/component v1.34.1
+	go.opentelemetry.io/collector/component v1.35.0
 	go.opentelemetry.io/collector/component/componenttest v0.128.1
 	go.opentelemetry.io/collector/connector v0.128.1
 	go.opentelemetry.io/collector/connector/xconnector v0.128.1
-	go.opentelemetry.io/collector/consumer v1.34.1
+	go.opentelemetry.io/collector/consumer v1.35.0
 	go.opentelemetry.io/collector/consumer/consumertest v0.128.1
 	go.opentelemetry.io/collector/consumer/xconsumer v0.128.1
-	go.opentelemetry.io/collector/pdata v1.34.1
+	go.opentelemetry.io/collector/pdata v1.35.0
 	go.opentelemetry.io/collector/pdata/pprofile v0.128.1
 	go.uber.org/goleak v1.3.0
 )
@@ -28,7 +28,7 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
-	go.opentelemetry.io/collector/featuregate v1.34.1 // indirect
+	go.opentelemetry.io/collector/featuregate v1.35.0 // indirect
 	go.opentelemetry.io/collector/internal/fanoutconsumer v0.128.1 // indirect
 	go.opentelemetry.io/collector/internal/telemetry v0.128.1 // indirect
 	go.opentelemetry.io/collector/pipeline v0.128.1 // indirect

--- a/connector/connectortest/go.mod
+++ b/connector/connectortest/go.mod
@@ -6,14 +6,14 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/component v1.35.0
-	go.opentelemetry.io/collector/component/componenttest v0.128.1
-	go.opentelemetry.io/collector/connector v0.128.1
-	go.opentelemetry.io/collector/connector/xconnector v0.128.1
+	go.opentelemetry.io/collector/component/componenttest v0.129.0
+	go.opentelemetry.io/collector/connector v0.129.0
+	go.opentelemetry.io/collector/connector/xconnector v0.129.0
 	go.opentelemetry.io/collector/consumer v1.35.0
-	go.opentelemetry.io/collector/consumer/consumertest v0.128.1
-	go.opentelemetry.io/collector/consumer/xconsumer v0.128.1
+	go.opentelemetry.io/collector/consumer/consumertest v0.129.0
+	go.opentelemetry.io/collector/consumer/xconsumer v0.129.0
 	go.opentelemetry.io/collector/pdata v1.35.0
-	go.opentelemetry.io/collector/pdata/pprofile v0.128.1
+	go.opentelemetry.io/collector/pdata/pprofile v0.129.0
 	go.uber.org/goleak v1.3.0
 )
 
@@ -29,10 +29,10 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/collector/featuregate v1.35.0 // indirect
-	go.opentelemetry.io/collector/internal/fanoutconsumer v0.128.1 // indirect
-	go.opentelemetry.io/collector/internal/telemetry v0.128.1 // indirect
-	go.opentelemetry.io/collector/pipeline v0.128.1 // indirect
-	go.opentelemetry.io/collector/pipeline/xpipeline v0.128.1 // indirect
+	go.opentelemetry.io/collector/internal/fanoutconsumer v0.129.0 // indirect
+	go.opentelemetry.io/collector/internal/telemetry v0.129.0 // indirect
+	go.opentelemetry.io/collector/pipeline v0.129.0 // indirect
+	go.opentelemetry.io/collector/pipeline/xpipeline v0.129.0 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.11.0 // indirect
 	go.opentelemetry.io/otel v1.36.0 // indirect
 	go.opentelemetry.io/otel/log v0.12.2 // indirect

--- a/connector/forwardconnector/go.mod
+++ b/connector/forwardconnector/go.mod
@@ -4,14 +4,14 @@ go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0
-	go.opentelemetry.io/collector/component v1.34.1
+	go.opentelemetry.io/collector/component v1.35.0
 	go.opentelemetry.io/collector/component/componenttest v0.128.1
-	go.opentelemetry.io/collector/confmap v1.34.1
+	go.opentelemetry.io/collector/confmap v1.35.0
 	go.opentelemetry.io/collector/connector v0.128.1
 	go.opentelemetry.io/collector/connector/connectortest v0.128.1
-	go.opentelemetry.io/collector/consumer v1.34.1
+	go.opentelemetry.io/collector/consumer v1.35.0
 	go.opentelemetry.io/collector/consumer/consumertest v0.128.1
-	go.opentelemetry.io/collector/pdata v1.34.1
+	go.opentelemetry.io/collector/pdata v1.35.0
 	go.opentelemetry.io/collector/pipeline v0.128.1
 	go.uber.org/goleak v1.3.0
 )
@@ -37,7 +37,7 @@ require (
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/collector/connector/xconnector v0.128.1 // indirect
 	go.opentelemetry.io/collector/consumer/xconsumer v0.128.1 // indirect
-	go.opentelemetry.io/collector/featuregate v1.34.1 // indirect
+	go.opentelemetry.io/collector/featuregate v1.35.0 // indirect
 	go.opentelemetry.io/collector/internal/fanoutconsumer v0.128.1 // indirect
 	go.opentelemetry.io/collector/internal/telemetry v0.128.1 // indirect
 	go.opentelemetry.io/collector/pdata/pprofile v0.128.1 // indirect

--- a/connector/forwardconnector/go.mod
+++ b/connector/forwardconnector/go.mod
@@ -5,14 +5,14 @@ go 1.23.0
 require (
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/component v1.35.0
-	go.opentelemetry.io/collector/component/componenttest v0.128.1
+	go.opentelemetry.io/collector/component/componenttest v0.129.0
 	go.opentelemetry.io/collector/confmap v1.35.0
-	go.opentelemetry.io/collector/connector v0.128.1
-	go.opentelemetry.io/collector/connector/connectortest v0.128.1
+	go.opentelemetry.io/collector/connector v0.129.0
+	go.opentelemetry.io/collector/connector/connectortest v0.129.0
 	go.opentelemetry.io/collector/consumer v1.35.0
-	go.opentelemetry.io/collector/consumer/consumertest v0.128.1
+	go.opentelemetry.io/collector/consumer/consumertest v0.129.0
 	go.opentelemetry.io/collector/pdata v1.35.0
-	go.opentelemetry.io/collector/pipeline v0.128.1
+	go.opentelemetry.io/collector/pipeline v0.129.0
 	go.uber.org/goleak v1.3.0
 )
 
@@ -35,13 +35,13 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
-	go.opentelemetry.io/collector/connector/xconnector v0.128.1 // indirect
-	go.opentelemetry.io/collector/consumer/xconsumer v0.128.1 // indirect
+	go.opentelemetry.io/collector/connector/xconnector v0.129.0 // indirect
+	go.opentelemetry.io/collector/consumer/xconsumer v0.129.0 // indirect
 	go.opentelemetry.io/collector/featuregate v1.35.0 // indirect
-	go.opentelemetry.io/collector/internal/fanoutconsumer v0.128.1 // indirect
-	go.opentelemetry.io/collector/internal/telemetry v0.128.1 // indirect
-	go.opentelemetry.io/collector/pdata/pprofile v0.128.1 // indirect
-	go.opentelemetry.io/collector/pipeline/xpipeline v0.128.1 // indirect
+	go.opentelemetry.io/collector/internal/fanoutconsumer v0.129.0 // indirect
+	go.opentelemetry.io/collector/internal/telemetry v0.129.0 // indirect
+	go.opentelemetry.io/collector/pdata/pprofile v0.129.0 // indirect
+	go.opentelemetry.io/collector/pipeline/xpipeline v0.129.0 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.11.0 // indirect
 	go.opentelemetry.io/otel v1.36.0 // indirect
 	go.opentelemetry.io/otel/log v0.12.2 // indirect

--- a/connector/go.mod
+++ b/connector/go.mod
@@ -4,11 +4,11 @@ go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0
-	go.opentelemetry.io/collector/component v1.34.1
-	go.opentelemetry.io/collector/consumer v1.34.1
+	go.opentelemetry.io/collector/component v1.35.0
+	go.opentelemetry.io/collector/consumer v1.35.0
 	go.opentelemetry.io/collector/consumer/consumertest v0.128.1
 	go.opentelemetry.io/collector/internal/fanoutconsumer v0.128.1
-	go.opentelemetry.io/collector/pdata v1.34.1
+	go.opentelemetry.io/collector/pdata v1.35.0
 	go.opentelemetry.io/collector/pdata/testdata v0.128.1
 	go.opentelemetry.io/collector/pipeline v0.128.1
 	go.uber.org/goleak v1.3.0
@@ -28,7 +28,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/collector/consumer/xconsumer v0.128.1 // indirect
-	go.opentelemetry.io/collector/featuregate v1.34.1 // indirect
+	go.opentelemetry.io/collector/featuregate v1.35.0 // indirect
 	go.opentelemetry.io/collector/internal/telemetry v0.128.1 // indirect
 	go.opentelemetry.io/collector/pdata/pprofile v0.128.1 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.11.0 // indirect

--- a/connector/go.mod
+++ b/connector/go.mod
@@ -6,11 +6,11 @@ require (
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/component v1.35.0
 	go.opentelemetry.io/collector/consumer v1.35.0
-	go.opentelemetry.io/collector/consumer/consumertest v0.128.1
-	go.opentelemetry.io/collector/internal/fanoutconsumer v0.128.1
+	go.opentelemetry.io/collector/consumer/consumertest v0.129.0
+	go.opentelemetry.io/collector/internal/fanoutconsumer v0.129.0
 	go.opentelemetry.io/collector/pdata v1.35.0
-	go.opentelemetry.io/collector/pdata/testdata v0.128.1
-	go.opentelemetry.io/collector/pipeline v0.128.1
+	go.opentelemetry.io/collector/pdata/testdata v0.129.0
+	go.opentelemetry.io/collector/pipeline v0.129.0
 	go.uber.org/goleak v1.3.0
 	go.uber.org/multierr v1.11.0
 )
@@ -27,10 +27,10 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
-	go.opentelemetry.io/collector/consumer/xconsumer v0.128.1 // indirect
+	go.opentelemetry.io/collector/consumer/xconsumer v0.129.0 // indirect
 	go.opentelemetry.io/collector/featuregate v1.35.0 // indirect
-	go.opentelemetry.io/collector/internal/telemetry v0.128.1 // indirect
-	go.opentelemetry.io/collector/pdata/pprofile v0.128.1 // indirect
+	go.opentelemetry.io/collector/internal/telemetry v0.129.0 // indirect
+	go.opentelemetry.io/collector/pdata/pprofile v0.129.0 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.11.0 // indirect
 	go.opentelemetry.io/otel v1.36.0 // indirect
 	go.opentelemetry.io/otel/log v0.12.2 // indirect

--- a/connector/xconnector/go.mod
+++ b/connector/xconnector/go.mod
@@ -5,15 +5,15 @@ go 1.23.0
 require (
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/component v1.35.0
-	go.opentelemetry.io/collector/connector v0.128.1
+	go.opentelemetry.io/collector/connector v0.129.0
 	go.opentelemetry.io/collector/consumer v1.35.0
-	go.opentelemetry.io/collector/consumer/consumertest v0.128.1
-	go.opentelemetry.io/collector/consumer/xconsumer v0.128.1
-	go.opentelemetry.io/collector/internal/fanoutconsumer v0.128.1
-	go.opentelemetry.io/collector/pdata/pprofile v0.128.1
-	go.opentelemetry.io/collector/pdata/testdata v0.128.1
-	go.opentelemetry.io/collector/pipeline v0.128.1
-	go.opentelemetry.io/collector/pipeline/xpipeline v0.128.1
+	go.opentelemetry.io/collector/consumer/consumertest v0.129.0
+	go.opentelemetry.io/collector/consumer/xconsumer v0.129.0
+	go.opentelemetry.io/collector/internal/fanoutconsumer v0.129.0
+	go.opentelemetry.io/collector/pdata/pprofile v0.129.0
+	go.opentelemetry.io/collector/pdata/testdata v0.129.0
+	go.opentelemetry.io/collector/pipeline v0.129.0
+	go.opentelemetry.io/collector/pipeline/xpipeline v0.129.0
 )
 
 require (
@@ -29,7 +29,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/collector/featuregate v1.35.0 // indirect
-	go.opentelemetry.io/collector/internal/telemetry v0.128.1 // indirect
+	go.opentelemetry.io/collector/internal/telemetry v0.129.0 // indirect
 	go.opentelemetry.io/collector/pdata v1.35.0 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.11.0 // indirect
 	go.opentelemetry.io/otel v1.36.0 // indirect

--- a/connector/xconnector/go.mod
+++ b/connector/xconnector/go.mod
@@ -4,9 +4,9 @@ go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0
-	go.opentelemetry.io/collector/component v1.34.1
+	go.opentelemetry.io/collector/component v1.35.0
 	go.opentelemetry.io/collector/connector v0.128.1
-	go.opentelemetry.io/collector/consumer v1.34.1
+	go.opentelemetry.io/collector/consumer v1.35.0
 	go.opentelemetry.io/collector/consumer/consumertest v0.128.1
 	go.opentelemetry.io/collector/consumer/xconsumer v0.128.1
 	go.opentelemetry.io/collector/internal/fanoutconsumer v0.128.1
@@ -28,9 +28,9 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
-	go.opentelemetry.io/collector/featuregate v1.34.1 // indirect
+	go.opentelemetry.io/collector/featuregate v1.35.0 // indirect
 	go.opentelemetry.io/collector/internal/telemetry v0.128.1 // indirect
-	go.opentelemetry.io/collector/pdata v1.34.1 // indirect
+	go.opentelemetry.io/collector/pdata v1.35.0 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.11.0 // indirect
 	go.opentelemetry.io/otel v1.36.0 // indirect
 	go.opentelemetry.io/otel/log v0.12.2 // indirect

--- a/consumer/consumererror/go.mod
+++ b/consumer/consumererror/go.mod
@@ -5,8 +5,8 @@ go 1.23.0
 require (
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/pdata v1.35.0
-	go.opentelemetry.io/collector/pdata/pprofile v0.128.1
-	go.opentelemetry.io/collector/pdata/testdata v0.128.1
+	go.opentelemetry.io/collector/pdata/pprofile v0.129.0
+	go.opentelemetry.io/collector/pdata/testdata v0.129.0
 	go.uber.org/goleak v1.3.0
 )
 

--- a/consumer/consumererror/go.mod
+++ b/consumer/consumererror/go.mod
@@ -4,7 +4,7 @@ go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0
-	go.opentelemetry.io/collector/pdata v1.34.1
+	go.opentelemetry.io/collector/pdata v1.35.0
 	go.opentelemetry.io/collector/pdata/pprofile v0.128.1
 	go.opentelemetry.io/collector/pdata/testdata v0.128.1
 	go.uber.org/goleak v1.3.0

--- a/consumer/consumererror/xconsumererror/go.mod
+++ b/consumer/consumererror/xconsumererror/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	go.opentelemetry.io/collector/pdata v1.34.1 // indirect
+	go.opentelemetry.io/collector/pdata v1.35.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/net v0.39.0 // indirect
 	golang.org/x/sys v0.32.0 // indirect

--- a/consumer/consumererror/xconsumererror/go.mod
+++ b/consumer/consumererror/xconsumererror/go.mod
@@ -4,9 +4,9 @@ go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0
-	go.opentelemetry.io/collector/consumer/consumererror v0.128.1
-	go.opentelemetry.io/collector/pdata/pprofile v0.128.1
-	go.opentelemetry.io/collector/pdata/testdata v0.128.1
+	go.opentelemetry.io/collector/consumer/consumererror v0.129.0
+	go.opentelemetry.io/collector/pdata/pprofile v0.129.0
+	go.opentelemetry.io/collector/pdata/testdata v0.129.0
 )
 
 require (

--- a/consumer/consumertest/go.mod
+++ b/consumer/consumertest/go.mod
@@ -6,9 +6,9 @@ replace go.opentelemetry.io/collector/consumer => ../
 
 require (
 	github.com/stretchr/testify v1.10.0
-	go.opentelemetry.io/collector/consumer v1.34.1
+	go.opentelemetry.io/collector/consumer v1.35.0
 	go.opentelemetry.io/collector/consumer/xconsumer v0.128.1
-	go.opentelemetry.io/collector/pdata v1.34.1
+	go.opentelemetry.io/collector/pdata v1.35.0
 	go.opentelemetry.io/collector/pdata/pprofile v0.128.1
 	go.opentelemetry.io/collector/pdata/testdata v0.128.1
 	go.uber.org/goleak v1.3.0

--- a/consumer/consumertest/go.mod
+++ b/consumer/consumertest/go.mod
@@ -7,10 +7,10 @@ replace go.opentelemetry.io/collector/consumer => ../
 require (
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/consumer v1.35.0
-	go.opentelemetry.io/collector/consumer/xconsumer v0.128.1
+	go.opentelemetry.io/collector/consumer/xconsumer v0.129.0
 	go.opentelemetry.io/collector/pdata v1.35.0
-	go.opentelemetry.io/collector/pdata/pprofile v0.128.1
-	go.opentelemetry.io/collector/pdata/testdata v0.128.1
+	go.opentelemetry.io/collector/pdata/pprofile v0.129.0
+	go.opentelemetry.io/collector/pdata/testdata v0.129.0
 	go.uber.org/goleak v1.3.0
 )
 

--- a/consumer/go.mod
+++ b/consumer/go.mod
@@ -4,7 +4,7 @@ go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0
-	go.opentelemetry.io/collector/pdata v1.34.1
+	go.opentelemetry.io/collector/pdata v1.35.0
 	go.uber.org/goleak v1.3.0
 )
 

--- a/consumer/xconsumer/go.mod
+++ b/consumer/xconsumer/go.mod
@@ -4,7 +4,7 @@ go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0
-	go.opentelemetry.io/collector/consumer v1.34.1
+	go.opentelemetry.io/collector/consumer v1.35.0
 	go.opentelemetry.io/collector/pdata/pprofile v0.128.1
 )
 
@@ -15,7 +15,7 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	go.opentelemetry.io/collector/pdata v1.34.1 // indirect
+	go.opentelemetry.io/collector/pdata v1.35.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/net v0.39.0 // indirect
 	golang.org/x/sys v0.32.0 // indirect

--- a/consumer/xconsumer/go.mod
+++ b/consumer/xconsumer/go.mod
@@ -5,7 +5,7 @@ go 1.23.0
 require (
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/consumer v1.35.0
-	go.opentelemetry.io/collector/pdata/pprofile v0.128.1
+	go.opentelemetry.io/collector/pdata/pprofile v0.129.0
 )
 
 require (

--- a/exporter/debugexporter/go.mod
+++ b/exporter/debugexporter/go.mod
@@ -4,16 +4,16 @@ go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0
-	go.opentelemetry.io/collector/component v1.34.1
+	go.opentelemetry.io/collector/component v1.35.0
 	go.opentelemetry.io/collector/component/componenttest v0.128.1
 	go.opentelemetry.io/collector/config/configtelemetry v0.128.1
-	go.opentelemetry.io/collector/confmap v1.34.1
-	go.opentelemetry.io/collector/consumer v1.34.1
+	go.opentelemetry.io/collector/confmap v1.35.0
+	go.opentelemetry.io/collector/consumer v1.35.0
 	go.opentelemetry.io/collector/exporter v0.128.1
 	go.opentelemetry.io/collector/exporter/exporterhelper/xexporterhelper v0.128.1
 	go.opentelemetry.io/collector/exporter/exportertest v0.128.1
 	go.opentelemetry.io/collector/exporter/xexporter v0.128.1
-	go.opentelemetry.io/collector/pdata v1.34.1
+	go.opentelemetry.io/collector/pdata v1.35.0
 	go.opentelemetry.io/collector/pdata/pprofile v0.128.1
 	go.opentelemetry.io/collector/pdata/testdata v0.128.1
 	go.uber.org/goleak v1.3.0
@@ -41,20 +41,20 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
-	go.opentelemetry.io/collector/client v1.34.1 // indirect
-	go.opentelemetry.io/collector/config/configretry v1.34.1 // indirect
+	go.opentelemetry.io/collector/client v1.35.0 // indirect
+	go.opentelemetry.io/collector/config/configretry v1.35.0 // indirect
 	go.opentelemetry.io/collector/consumer/consumererror v0.128.1 // indirect
 	go.opentelemetry.io/collector/consumer/consumererror/xconsumererror v0.128.1 // indirect
 	go.opentelemetry.io/collector/consumer/consumertest v0.128.1 // indirect
 	go.opentelemetry.io/collector/consumer/xconsumer v0.128.1 // indirect
-	go.opentelemetry.io/collector/extension v1.34.1 // indirect
+	go.opentelemetry.io/collector/extension v1.35.0 // indirect
 	go.opentelemetry.io/collector/extension/xextension v0.128.1 // indirect
-	go.opentelemetry.io/collector/featuregate v1.34.1 // indirect
+	go.opentelemetry.io/collector/featuregate v1.35.0 // indirect
 	go.opentelemetry.io/collector/internal/telemetry v0.128.1 // indirect
 	go.opentelemetry.io/collector/pdata/xpdata v0.128.1 // indirect
 	go.opentelemetry.io/collector/pipeline v0.128.1 // indirect
 	go.opentelemetry.io/collector/pipeline/xpipeline v0.128.1 // indirect
-	go.opentelemetry.io/collector/receiver v1.34.1 // indirect
+	go.opentelemetry.io/collector/receiver v1.35.0 // indirect
 	go.opentelemetry.io/collector/receiver/receivertest v0.128.1 // indirect
 	go.opentelemetry.io/collector/receiver/xreceiver v0.128.1 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.11.0 // indirect

--- a/exporter/debugexporter/go.mod
+++ b/exporter/debugexporter/go.mod
@@ -5,17 +5,17 @@ go 1.23.0
 require (
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/component v1.35.0
-	go.opentelemetry.io/collector/component/componenttest v0.128.1
-	go.opentelemetry.io/collector/config/configtelemetry v0.128.1
+	go.opentelemetry.io/collector/component/componenttest v0.129.0
+	go.opentelemetry.io/collector/config/configtelemetry v0.129.0
 	go.opentelemetry.io/collector/confmap v1.35.0
 	go.opentelemetry.io/collector/consumer v1.35.0
-	go.opentelemetry.io/collector/exporter v0.128.1
-	go.opentelemetry.io/collector/exporter/exporterhelper/xexporterhelper v0.128.1
-	go.opentelemetry.io/collector/exporter/exportertest v0.128.1
-	go.opentelemetry.io/collector/exporter/xexporter v0.128.1
+	go.opentelemetry.io/collector/exporter v0.129.0
+	go.opentelemetry.io/collector/exporter/exporterhelper/xexporterhelper v0.129.0
+	go.opentelemetry.io/collector/exporter/exportertest v0.129.0
+	go.opentelemetry.io/collector/exporter/xexporter v0.129.0
 	go.opentelemetry.io/collector/pdata v1.35.0
-	go.opentelemetry.io/collector/pdata/pprofile v0.128.1
-	go.opentelemetry.io/collector/pdata/testdata v0.128.1
+	go.opentelemetry.io/collector/pdata/pprofile v0.129.0
+	go.opentelemetry.io/collector/pdata/testdata v0.129.0
 	go.uber.org/goleak v1.3.0
 	go.uber.org/zap v1.27.0
 	golang.org/x/sys v0.33.0
@@ -43,20 +43,20 @@ require (
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/collector/client v1.35.0 // indirect
 	go.opentelemetry.io/collector/config/configretry v1.35.0 // indirect
-	go.opentelemetry.io/collector/consumer/consumererror v0.128.1 // indirect
-	go.opentelemetry.io/collector/consumer/consumererror/xconsumererror v0.128.1 // indirect
-	go.opentelemetry.io/collector/consumer/consumertest v0.128.1 // indirect
-	go.opentelemetry.io/collector/consumer/xconsumer v0.128.1 // indirect
+	go.opentelemetry.io/collector/consumer/consumererror v0.129.0 // indirect
+	go.opentelemetry.io/collector/consumer/consumererror/xconsumererror v0.129.0 // indirect
+	go.opentelemetry.io/collector/consumer/consumertest v0.129.0 // indirect
+	go.opentelemetry.io/collector/consumer/xconsumer v0.129.0 // indirect
 	go.opentelemetry.io/collector/extension v1.35.0 // indirect
-	go.opentelemetry.io/collector/extension/xextension v0.128.1 // indirect
+	go.opentelemetry.io/collector/extension/xextension v0.129.0 // indirect
 	go.opentelemetry.io/collector/featuregate v1.35.0 // indirect
-	go.opentelemetry.io/collector/internal/telemetry v0.128.1 // indirect
-	go.opentelemetry.io/collector/pdata/xpdata v0.128.1 // indirect
-	go.opentelemetry.io/collector/pipeline v0.128.1 // indirect
-	go.opentelemetry.io/collector/pipeline/xpipeline v0.128.1 // indirect
+	go.opentelemetry.io/collector/internal/telemetry v0.129.0 // indirect
+	go.opentelemetry.io/collector/pdata/xpdata v0.129.0 // indirect
+	go.opentelemetry.io/collector/pipeline v0.129.0 // indirect
+	go.opentelemetry.io/collector/pipeline/xpipeline v0.129.0 // indirect
 	go.opentelemetry.io/collector/receiver v1.35.0 // indirect
-	go.opentelemetry.io/collector/receiver/receivertest v0.128.1 // indirect
-	go.opentelemetry.io/collector/receiver/xreceiver v0.128.1 // indirect
+	go.opentelemetry.io/collector/receiver/receivertest v0.129.0 // indirect
+	go.opentelemetry.io/collector/receiver/xreceiver v0.129.0 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.11.0 // indirect
 	go.opentelemetry.io/otel v1.36.0 // indirect
 	go.opentelemetry.io/otel/log v0.12.2 // indirect

--- a/exporter/exporterhelper/xexporterhelper/go.mod
+++ b/exporter/exporterhelper/xexporterhelper/go.mod
@@ -4,9 +4,9 @@ go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0
-	go.opentelemetry.io/collector/component v1.34.1
+	go.opentelemetry.io/collector/component v1.35.0
 	go.opentelemetry.io/collector/component/componenttest v0.128.1
-	go.opentelemetry.io/collector/consumer v1.34.1
+	go.opentelemetry.io/collector/consumer v1.35.0
 	go.opentelemetry.io/collector/consumer/consumererror v0.128.1
 	go.opentelemetry.io/collector/consumer/consumererror/xconsumererror v0.128.1
 	go.opentelemetry.io/collector/consumer/consumertest v0.128.1
@@ -37,15 +37,15 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
-	go.opentelemetry.io/collector/client v1.34.1 // indirect
-	go.opentelemetry.io/collector/config/configretry v1.34.1 // indirect
-	go.opentelemetry.io/collector/extension v1.34.1 // indirect
+	go.opentelemetry.io/collector/client v1.35.0 // indirect
+	go.opentelemetry.io/collector/config/configretry v1.35.0 // indirect
+	go.opentelemetry.io/collector/extension v1.35.0 // indirect
 	go.opentelemetry.io/collector/extension/xextension v0.128.1 // indirect
-	go.opentelemetry.io/collector/featuregate v1.34.1 // indirect
+	go.opentelemetry.io/collector/featuregate v1.35.0 // indirect
 	go.opentelemetry.io/collector/internal/telemetry v0.128.1 // indirect
-	go.opentelemetry.io/collector/pdata v1.34.1 // indirect
+	go.opentelemetry.io/collector/pdata v1.35.0 // indirect
 	go.opentelemetry.io/collector/pipeline v0.128.1 // indirect
-	go.opentelemetry.io/collector/receiver v1.34.1 // indirect
+	go.opentelemetry.io/collector/receiver v1.35.0 // indirect
 	go.opentelemetry.io/collector/receiver/receivertest v0.128.1 // indirect
 	go.opentelemetry.io/collector/receiver/xreceiver v0.128.1 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.11.0 // indirect

--- a/exporter/exporterhelper/xexporterhelper/go.mod
+++ b/exporter/exporterhelper/xexporterhelper/go.mod
@@ -5,19 +5,19 @@ go 1.23.0
 require (
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/component v1.35.0
-	go.opentelemetry.io/collector/component/componenttest v0.128.1
+	go.opentelemetry.io/collector/component/componenttest v0.129.0
 	go.opentelemetry.io/collector/consumer v1.35.0
-	go.opentelemetry.io/collector/consumer/consumererror v0.128.1
-	go.opentelemetry.io/collector/consumer/consumererror/xconsumererror v0.128.1
-	go.opentelemetry.io/collector/consumer/consumertest v0.128.1
-	go.opentelemetry.io/collector/consumer/xconsumer v0.128.1
-	go.opentelemetry.io/collector/exporter v0.128.1
-	go.opentelemetry.io/collector/exporter/exportertest v0.128.1
-	go.opentelemetry.io/collector/exporter/xexporter v0.128.1
-	go.opentelemetry.io/collector/pdata/pprofile v0.128.1
-	go.opentelemetry.io/collector/pdata/testdata v0.128.1
-	go.opentelemetry.io/collector/pdata/xpdata v0.128.1
-	go.opentelemetry.io/collector/pipeline/xpipeline v0.128.1
+	go.opentelemetry.io/collector/consumer/consumererror v0.129.0
+	go.opentelemetry.io/collector/consumer/consumererror/xconsumererror v0.129.0
+	go.opentelemetry.io/collector/consumer/consumertest v0.129.0
+	go.opentelemetry.io/collector/consumer/xconsumer v0.129.0
+	go.opentelemetry.io/collector/exporter v0.129.0
+	go.opentelemetry.io/collector/exporter/exportertest v0.129.0
+	go.opentelemetry.io/collector/exporter/xexporter v0.129.0
+	go.opentelemetry.io/collector/pdata/pprofile v0.129.0
+	go.opentelemetry.io/collector/pdata/testdata v0.129.0
+	go.opentelemetry.io/collector/pdata/xpdata v0.129.0
+	go.opentelemetry.io/collector/pipeline/xpipeline v0.129.0
 	go.opentelemetry.io/otel v1.36.0
 	go.opentelemetry.io/otel/sdk v1.36.0
 	go.opentelemetry.io/otel/trace v1.36.0
@@ -40,14 +40,14 @@ require (
 	go.opentelemetry.io/collector/client v1.35.0 // indirect
 	go.opentelemetry.io/collector/config/configretry v1.35.0 // indirect
 	go.opentelemetry.io/collector/extension v1.35.0 // indirect
-	go.opentelemetry.io/collector/extension/xextension v0.128.1 // indirect
+	go.opentelemetry.io/collector/extension/xextension v0.129.0 // indirect
 	go.opentelemetry.io/collector/featuregate v1.35.0 // indirect
-	go.opentelemetry.io/collector/internal/telemetry v0.128.1 // indirect
+	go.opentelemetry.io/collector/internal/telemetry v0.129.0 // indirect
 	go.opentelemetry.io/collector/pdata v1.35.0 // indirect
-	go.opentelemetry.io/collector/pipeline v0.128.1 // indirect
+	go.opentelemetry.io/collector/pipeline v0.129.0 // indirect
 	go.opentelemetry.io/collector/receiver v1.35.0 // indirect
-	go.opentelemetry.io/collector/receiver/receivertest v0.128.1 // indirect
-	go.opentelemetry.io/collector/receiver/xreceiver v0.128.1 // indirect
+	go.opentelemetry.io/collector/receiver/receivertest v0.129.0 // indirect
+	go.opentelemetry.io/collector/receiver/xreceiver v0.129.0 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.11.0 // indirect
 	go.opentelemetry.io/otel/log v0.12.2 // indirect
 	go.opentelemetry.io/otel/metric v1.36.0 // indirect

--- a/exporter/exportertest/go.mod
+++ b/exporter/exportertest/go.mod
@@ -5,18 +5,18 @@ go 1.23.0
 require (
 	github.com/google/uuid v1.6.0
 	github.com/stretchr/testify v1.10.0
-	go.opentelemetry.io/collector/component v1.34.1
+	go.opentelemetry.io/collector/component v1.35.0
 	go.opentelemetry.io/collector/component/componenttest v0.128.1
-	go.opentelemetry.io/collector/config/configretry v1.34.1
-	go.opentelemetry.io/collector/consumer v1.34.1
+	go.opentelemetry.io/collector/config/configretry v1.35.0
+	go.opentelemetry.io/collector/consumer v1.35.0
 	go.opentelemetry.io/collector/consumer/consumererror v0.128.1
 	go.opentelemetry.io/collector/consumer/consumertest v0.128.1
 	go.opentelemetry.io/collector/exporter v0.128.1
 	go.opentelemetry.io/collector/exporter/xexporter v0.128.1
-	go.opentelemetry.io/collector/pdata v1.34.1
+	go.opentelemetry.io/collector/pdata v1.35.0
 	go.opentelemetry.io/collector/pdata/pprofile v0.128.1
 	go.opentelemetry.io/collector/pipeline v0.128.1
-	go.opentelemetry.io/collector/receiver v1.34.1
+	go.opentelemetry.io/collector/receiver v1.35.0
 	go.opentelemetry.io/collector/receiver/receivertest v0.128.1
 	google.golang.org/grpc v1.73.0
 )
@@ -33,11 +33,11 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
-	go.opentelemetry.io/collector/client v1.34.1 // indirect
+	go.opentelemetry.io/collector/client v1.35.0 // indirect
 	go.opentelemetry.io/collector/consumer/xconsumer v0.128.1 // indirect
-	go.opentelemetry.io/collector/extension v1.34.1 // indirect
+	go.opentelemetry.io/collector/extension v1.35.0 // indirect
 	go.opentelemetry.io/collector/extension/xextension v0.128.1 // indirect
-	go.opentelemetry.io/collector/featuregate v1.34.1 // indirect
+	go.opentelemetry.io/collector/featuregate v1.35.0 // indirect
 	go.opentelemetry.io/collector/internal/telemetry v0.128.1 // indirect
 	go.opentelemetry.io/collector/pdata/xpdata v0.128.1 // indirect
 	go.opentelemetry.io/collector/receiver/xreceiver v0.128.1 // indirect

--- a/exporter/exportertest/go.mod
+++ b/exporter/exportertest/go.mod
@@ -6,18 +6,18 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/component v1.35.0
-	go.opentelemetry.io/collector/component/componenttest v0.128.1
+	go.opentelemetry.io/collector/component/componenttest v0.129.0
 	go.opentelemetry.io/collector/config/configretry v1.35.0
 	go.opentelemetry.io/collector/consumer v1.35.0
-	go.opentelemetry.io/collector/consumer/consumererror v0.128.1
-	go.opentelemetry.io/collector/consumer/consumertest v0.128.1
-	go.opentelemetry.io/collector/exporter v0.128.1
-	go.opentelemetry.io/collector/exporter/xexporter v0.128.1
+	go.opentelemetry.io/collector/consumer/consumererror v0.129.0
+	go.opentelemetry.io/collector/consumer/consumertest v0.129.0
+	go.opentelemetry.io/collector/exporter v0.129.0
+	go.opentelemetry.io/collector/exporter/xexporter v0.129.0
 	go.opentelemetry.io/collector/pdata v1.35.0
-	go.opentelemetry.io/collector/pdata/pprofile v0.128.1
-	go.opentelemetry.io/collector/pipeline v0.128.1
+	go.opentelemetry.io/collector/pdata/pprofile v0.129.0
+	go.opentelemetry.io/collector/pipeline v0.129.0
 	go.opentelemetry.io/collector/receiver v1.35.0
-	go.opentelemetry.io/collector/receiver/receivertest v0.128.1
+	go.opentelemetry.io/collector/receiver/receivertest v0.129.0
 	google.golang.org/grpc v1.73.0
 )
 
@@ -34,13 +34,13 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/collector/client v1.35.0 // indirect
-	go.opentelemetry.io/collector/consumer/xconsumer v0.128.1 // indirect
+	go.opentelemetry.io/collector/consumer/xconsumer v0.129.0 // indirect
 	go.opentelemetry.io/collector/extension v1.35.0 // indirect
-	go.opentelemetry.io/collector/extension/xextension v0.128.1 // indirect
+	go.opentelemetry.io/collector/extension/xextension v0.129.0 // indirect
 	go.opentelemetry.io/collector/featuregate v1.35.0 // indirect
-	go.opentelemetry.io/collector/internal/telemetry v0.128.1 // indirect
-	go.opentelemetry.io/collector/pdata/xpdata v0.128.1 // indirect
-	go.opentelemetry.io/collector/receiver/xreceiver v0.128.1 // indirect
+	go.opentelemetry.io/collector/internal/telemetry v0.129.0 // indirect
+	go.opentelemetry.io/collector/pdata/xpdata v0.129.0 // indirect
+	go.opentelemetry.io/collector/receiver/xreceiver v0.129.0 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.11.0 // indirect
 	go.opentelemetry.io/otel v1.36.0 // indirect
 	go.opentelemetry.io/otel/log v0.12.2 // indirect

--- a/exporter/go.mod
+++ b/exporter/go.mod
@@ -6,18 +6,18 @@ require (
 	github.com/cenkalti/backoff/v5 v5.0.2
 	github.com/gogo/protobuf v1.3.2
 	github.com/stretchr/testify v1.10.0
-	go.opentelemetry.io/collector/client v1.34.1
-	go.opentelemetry.io/collector/component v1.34.1
+	go.opentelemetry.io/collector/client v1.35.0
+	go.opentelemetry.io/collector/component v1.35.0
 	go.opentelemetry.io/collector/component/componenttest v0.128.1
-	go.opentelemetry.io/collector/config/configretry v1.34.1
-	go.opentelemetry.io/collector/consumer v1.34.1
+	go.opentelemetry.io/collector/config/configretry v1.35.0
+	go.opentelemetry.io/collector/consumer v1.35.0
 	go.opentelemetry.io/collector/consumer/consumererror v0.128.1
 	go.opentelemetry.io/collector/consumer/consumertest v0.128.1
 	go.opentelemetry.io/collector/exporter/exportertest v0.128.1
 	go.opentelemetry.io/collector/extension/extensiontest v0.128.1
 	go.opentelemetry.io/collector/extension/xextension v0.128.1
-	go.opentelemetry.io/collector/featuregate v1.34.1
-	go.opentelemetry.io/collector/pdata v1.34.1
+	go.opentelemetry.io/collector/featuregate v1.35.0
+	go.opentelemetry.io/collector/pdata v1.35.0
 	go.opentelemetry.io/collector/pdata/pprofile v0.128.1
 	go.opentelemetry.io/collector/pdata/testdata v0.128.1
 	go.opentelemetry.io/collector/pdata/xpdata v0.128.1
@@ -45,9 +45,9 @@ require (
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/collector/consumer/xconsumer v0.128.1 // indirect
 	go.opentelemetry.io/collector/exporter/xexporter v0.128.1 // indirect
-	go.opentelemetry.io/collector/extension v1.34.1 // indirect
+	go.opentelemetry.io/collector/extension v1.35.0 // indirect
 	go.opentelemetry.io/collector/internal/telemetry v0.128.1 // indirect
-	go.opentelemetry.io/collector/receiver v1.34.1 // indirect
+	go.opentelemetry.io/collector/receiver v1.35.0 // indirect
 	go.opentelemetry.io/collector/receiver/receivertest v0.128.1 // indirect
 	go.opentelemetry.io/collector/receiver/xreceiver v0.128.1 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.11.0 // indirect

--- a/exporter/go.mod
+++ b/exporter/go.mod
@@ -8,20 +8,20 @@ require (
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/client v1.35.0
 	go.opentelemetry.io/collector/component v1.35.0
-	go.opentelemetry.io/collector/component/componenttest v0.128.1
+	go.opentelemetry.io/collector/component/componenttest v0.129.0
 	go.opentelemetry.io/collector/config/configretry v1.35.0
 	go.opentelemetry.io/collector/consumer v1.35.0
-	go.opentelemetry.io/collector/consumer/consumererror v0.128.1
-	go.opentelemetry.io/collector/consumer/consumertest v0.128.1
-	go.opentelemetry.io/collector/exporter/exportertest v0.128.1
-	go.opentelemetry.io/collector/extension/extensiontest v0.128.1
-	go.opentelemetry.io/collector/extension/xextension v0.128.1
+	go.opentelemetry.io/collector/consumer/consumererror v0.129.0
+	go.opentelemetry.io/collector/consumer/consumertest v0.129.0
+	go.opentelemetry.io/collector/exporter/exportertest v0.129.0
+	go.opentelemetry.io/collector/extension/extensiontest v0.129.0
+	go.opentelemetry.io/collector/extension/xextension v0.129.0
 	go.opentelemetry.io/collector/featuregate v1.35.0
 	go.opentelemetry.io/collector/pdata v1.35.0
-	go.opentelemetry.io/collector/pdata/pprofile v0.128.1
-	go.opentelemetry.io/collector/pdata/testdata v0.128.1
-	go.opentelemetry.io/collector/pdata/xpdata v0.128.1
-	go.opentelemetry.io/collector/pipeline v0.128.1
+	go.opentelemetry.io/collector/pdata/pprofile v0.129.0
+	go.opentelemetry.io/collector/pdata/testdata v0.129.0
+	go.opentelemetry.io/collector/pdata/xpdata v0.129.0
+	go.opentelemetry.io/collector/pipeline v0.129.0
 	go.opentelemetry.io/otel v1.36.0
 	go.opentelemetry.io/otel/metric v1.36.0
 	go.opentelemetry.io/otel/sdk v1.36.0
@@ -43,13 +43,13 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
-	go.opentelemetry.io/collector/consumer/xconsumer v0.128.1 // indirect
-	go.opentelemetry.io/collector/exporter/xexporter v0.128.1 // indirect
+	go.opentelemetry.io/collector/consumer/xconsumer v0.129.0 // indirect
+	go.opentelemetry.io/collector/exporter/xexporter v0.129.0 // indirect
 	go.opentelemetry.io/collector/extension v1.35.0 // indirect
-	go.opentelemetry.io/collector/internal/telemetry v0.128.1 // indirect
+	go.opentelemetry.io/collector/internal/telemetry v0.129.0 // indirect
 	go.opentelemetry.io/collector/receiver v1.35.0 // indirect
-	go.opentelemetry.io/collector/receiver/receivertest v0.128.1 // indirect
-	go.opentelemetry.io/collector/receiver/xreceiver v0.128.1 // indirect
+	go.opentelemetry.io/collector/receiver/receivertest v0.129.0 // indirect
+	go.opentelemetry.io/collector/receiver/xreceiver v0.129.0 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.11.0 // indirect
 	go.opentelemetry.io/otel/log v0.12.2 // indirect
 	golang.org/x/net v0.39.0 // indirect

--- a/exporter/nopexporter/go.mod
+++ b/exporter/nopexporter/go.mod
@@ -4,13 +4,13 @@ go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0
-	go.opentelemetry.io/collector/component v1.34.1
+	go.opentelemetry.io/collector/component v1.35.0
 	go.opentelemetry.io/collector/component/componenttest v0.128.1
-	go.opentelemetry.io/collector/confmap v1.34.1
+	go.opentelemetry.io/collector/confmap v1.35.0
 	go.opentelemetry.io/collector/consumer/consumertest v0.128.1
 	go.opentelemetry.io/collector/exporter v0.128.1
 	go.opentelemetry.io/collector/exporter/exportertest v0.128.1
-	go.opentelemetry.io/collector/pdata v1.34.1
+	go.opentelemetry.io/collector/pdata v1.35.0
 	go.uber.org/goleak v1.3.0
 )
 
@@ -33,15 +33,15 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
-	go.opentelemetry.io/collector/consumer v1.34.1 // indirect
+	go.opentelemetry.io/collector/consumer v1.35.0 // indirect
 	go.opentelemetry.io/collector/consumer/consumererror v0.128.1 // indirect
 	go.opentelemetry.io/collector/consumer/xconsumer v0.128.1 // indirect
 	go.opentelemetry.io/collector/exporter/xexporter v0.128.1 // indirect
-	go.opentelemetry.io/collector/featuregate v1.34.1 // indirect
+	go.opentelemetry.io/collector/featuregate v1.35.0 // indirect
 	go.opentelemetry.io/collector/internal/telemetry v0.128.1 // indirect
 	go.opentelemetry.io/collector/pdata/pprofile v0.128.1 // indirect
 	go.opentelemetry.io/collector/pipeline v0.128.1 // indirect
-	go.opentelemetry.io/collector/receiver v1.34.1 // indirect
+	go.opentelemetry.io/collector/receiver v1.35.0 // indirect
 	go.opentelemetry.io/collector/receiver/receivertest v0.128.1 // indirect
 	go.opentelemetry.io/collector/receiver/xreceiver v0.128.1 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.11.0 // indirect

--- a/exporter/nopexporter/go.mod
+++ b/exporter/nopexporter/go.mod
@@ -5,11 +5,11 @@ go 1.23.0
 require (
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/component v1.35.0
-	go.opentelemetry.io/collector/component/componenttest v0.128.1
+	go.opentelemetry.io/collector/component/componenttest v0.129.0
 	go.opentelemetry.io/collector/confmap v1.35.0
-	go.opentelemetry.io/collector/consumer/consumertest v0.128.1
-	go.opentelemetry.io/collector/exporter v0.128.1
-	go.opentelemetry.io/collector/exporter/exportertest v0.128.1
+	go.opentelemetry.io/collector/consumer/consumertest v0.129.0
+	go.opentelemetry.io/collector/exporter v0.129.0
+	go.opentelemetry.io/collector/exporter/exportertest v0.129.0
 	go.opentelemetry.io/collector/pdata v1.35.0
 	go.uber.org/goleak v1.3.0
 )
@@ -34,16 +34,16 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/collector/consumer v1.35.0 // indirect
-	go.opentelemetry.io/collector/consumer/consumererror v0.128.1 // indirect
-	go.opentelemetry.io/collector/consumer/xconsumer v0.128.1 // indirect
-	go.opentelemetry.io/collector/exporter/xexporter v0.128.1 // indirect
+	go.opentelemetry.io/collector/consumer/consumererror v0.129.0 // indirect
+	go.opentelemetry.io/collector/consumer/xconsumer v0.129.0 // indirect
+	go.opentelemetry.io/collector/exporter/xexporter v0.129.0 // indirect
 	go.opentelemetry.io/collector/featuregate v1.35.0 // indirect
-	go.opentelemetry.io/collector/internal/telemetry v0.128.1 // indirect
-	go.opentelemetry.io/collector/pdata/pprofile v0.128.1 // indirect
-	go.opentelemetry.io/collector/pipeline v0.128.1 // indirect
+	go.opentelemetry.io/collector/internal/telemetry v0.129.0 // indirect
+	go.opentelemetry.io/collector/pdata/pprofile v0.129.0 // indirect
+	go.opentelemetry.io/collector/pipeline v0.129.0 // indirect
 	go.opentelemetry.io/collector/receiver v1.35.0 // indirect
-	go.opentelemetry.io/collector/receiver/receivertest v0.128.1 // indirect
-	go.opentelemetry.io/collector/receiver/xreceiver v0.128.1 // indirect
+	go.opentelemetry.io/collector/receiver/receivertest v0.129.0 // indirect
+	go.opentelemetry.io/collector/receiver/xreceiver v0.129.0 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.11.0 // indirect
 	go.opentelemetry.io/otel v1.36.0 // indirect
 	go.opentelemetry.io/otel/log v0.12.2 // indirect

--- a/exporter/otlpexporter/go.mod
+++ b/exporter/otlpexporter/go.mod
@@ -4,26 +4,26 @@ go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0
-	go.opentelemetry.io/collector v0.128.1
+	go.opentelemetry.io/collector v0.129.0
 	go.opentelemetry.io/collector/component v1.35.0
-	go.opentelemetry.io/collector/component/componenttest v0.128.1
-	go.opentelemetry.io/collector/config/configauth v0.128.1
+	go.opentelemetry.io/collector/component/componenttest v0.129.0
+	go.opentelemetry.io/collector/config/configauth v0.129.0
 	go.opentelemetry.io/collector/config/configcompression v1.35.0
-	go.opentelemetry.io/collector/config/configgrpc v0.128.1
+	go.opentelemetry.io/collector/config/configgrpc v0.129.0
 	go.opentelemetry.io/collector/config/configopaque v1.35.0
 	go.opentelemetry.io/collector/config/configretry v1.35.0
 	go.opentelemetry.io/collector/config/configtls v1.35.0
 	go.opentelemetry.io/collector/confmap v1.35.0
-	go.opentelemetry.io/collector/confmap/xconfmap v0.128.1
+	go.opentelemetry.io/collector/confmap/xconfmap v0.129.0
 	go.opentelemetry.io/collector/consumer v1.35.0
-	go.opentelemetry.io/collector/consumer/consumererror v0.128.1
-	go.opentelemetry.io/collector/exporter v0.128.1
-	go.opentelemetry.io/collector/exporter/exporterhelper/xexporterhelper v0.128.1
-	go.opentelemetry.io/collector/exporter/exportertest v0.128.1
-	go.opentelemetry.io/collector/exporter/xexporter v0.128.1
+	go.opentelemetry.io/collector/consumer/consumererror v0.129.0
+	go.opentelemetry.io/collector/exporter v0.129.0
+	go.opentelemetry.io/collector/exporter/exporterhelper/xexporterhelper v0.129.0
+	go.opentelemetry.io/collector/exporter/exportertest v0.129.0
+	go.opentelemetry.io/collector/exporter/xexporter v0.129.0
 	go.opentelemetry.io/collector/pdata v1.35.0
-	go.opentelemetry.io/collector/pdata/pprofile v0.128.1
-	go.opentelemetry.io/collector/pdata/testdata v0.128.1
+	go.opentelemetry.io/collector/pdata/pprofile v0.129.0
+	go.opentelemetry.io/collector/pdata/testdata v0.129.0
 	go.uber.org/goleak v1.3.0
 	go.uber.org/zap v1.27.0
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250519155744-55703ea1f237
@@ -58,23 +58,23 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/collector/client v1.35.0 // indirect
-	go.opentelemetry.io/collector/config/configmiddleware v0.128.1 // indirect
+	go.opentelemetry.io/collector/config/configmiddleware v0.129.0 // indirect
 	go.opentelemetry.io/collector/config/confignet v1.35.0 // indirect
-	go.opentelemetry.io/collector/consumer/consumererror/xconsumererror v0.128.1 // indirect
-	go.opentelemetry.io/collector/consumer/consumertest v0.128.1 // indirect
-	go.opentelemetry.io/collector/consumer/xconsumer v0.128.1 // indirect
+	go.opentelemetry.io/collector/consumer/consumererror/xconsumererror v0.129.0 // indirect
+	go.opentelemetry.io/collector/consumer/consumertest v0.129.0 // indirect
+	go.opentelemetry.io/collector/consumer/xconsumer v0.129.0 // indirect
 	go.opentelemetry.io/collector/extension v1.35.0 // indirect
 	go.opentelemetry.io/collector/extension/extensionauth v1.35.0 // indirect
-	go.opentelemetry.io/collector/extension/extensionmiddleware v0.128.1 // indirect
-	go.opentelemetry.io/collector/extension/xextension v0.128.1 // indirect
+	go.opentelemetry.io/collector/extension/extensionmiddleware v0.129.0 // indirect
+	go.opentelemetry.io/collector/extension/xextension v0.129.0 // indirect
 	go.opentelemetry.io/collector/featuregate v1.35.0 // indirect
-	go.opentelemetry.io/collector/internal/telemetry v0.128.1 // indirect
-	go.opentelemetry.io/collector/pdata/xpdata v0.128.1 // indirect
-	go.opentelemetry.io/collector/pipeline v0.128.1 // indirect
-	go.opentelemetry.io/collector/pipeline/xpipeline v0.128.1 // indirect
+	go.opentelemetry.io/collector/internal/telemetry v0.129.0 // indirect
+	go.opentelemetry.io/collector/pdata/xpdata v0.129.0 // indirect
+	go.opentelemetry.io/collector/pipeline v0.129.0 // indirect
+	go.opentelemetry.io/collector/pipeline/xpipeline v0.129.0 // indirect
 	go.opentelemetry.io/collector/receiver v1.35.0 // indirect
-	go.opentelemetry.io/collector/receiver/receivertest v0.128.1 // indirect
-	go.opentelemetry.io/collector/receiver/xreceiver v0.128.1 // indirect
+	go.opentelemetry.io/collector/receiver/receivertest v0.129.0 // indirect
+	go.opentelemetry.io/collector/receiver/xreceiver v0.129.0 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.11.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.61.0 // indirect
 	go.opentelemetry.io/otel v1.36.0 // indirect

--- a/exporter/otlpexporter/go.mod
+++ b/exporter/otlpexporter/go.mod
@@ -5,23 +5,23 @@ go 1.23.0
 require (
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector v0.128.1
-	go.opentelemetry.io/collector/component v1.34.1
+	go.opentelemetry.io/collector/component v1.35.0
 	go.opentelemetry.io/collector/component/componenttest v0.128.1
 	go.opentelemetry.io/collector/config/configauth v0.128.1
-	go.opentelemetry.io/collector/config/configcompression v1.34.1
+	go.opentelemetry.io/collector/config/configcompression v1.35.0
 	go.opentelemetry.io/collector/config/configgrpc v0.128.1
-	go.opentelemetry.io/collector/config/configopaque v1.34.1
-	go.opentelemetry.io/collector/config/configretry v1.34.1
-	go.opentelemetry.io/collector/config/configtls v1.34.1
-	go.opentelemetry.io/collector/confmap v1.34.1
+	go.opentelemetry.io/collector/config/configopaque v1.35.0
+	go.opentelemetry.io/collector/config/configretry v1.35.0
+	go.opentelemetry.io/collector/config/configtls v1.35.0
+	go.opentelemetry.io/collector/confmap v1.35.0
 	go.opentelemetry.io/collector/confmap/xconfmap v0.128.1
-	go.opentelemetry.io/collector/consumer v1.34.1
+	go.opentelemetry.io/collector/consumer v1.35.0
 	go.opentelemetry.io/collector/consumer/consumererror v0.128.1
 	go.opentelemetry.io/collector/exporter v0.128.1
 	go.opentelemetry.io/collector/exporter/exporterhelper/xexporterhelper v0.128.1
 	go.opentelemetry.io/collector/exporter/exportertest v0.128.1
 	go.opentelemetry.io/collector/exporter/xexporter v0.128.1
-	go.opentelemetry.io/collector/pdata v1.34.1
+	go.opentelemetry.io/collector/pdata v1.35.0
 	go.opentelemetry.io/collector/pdata/pprofile v0.128.1
 	go.opentelemetry.io/collector/pdata/testdata v0.128.1
 	go.uber.org/goleak v1.3.0
@@ -57,22 +57,22 @@ require (
 	github.com/mostynb/go-grpc-compression v1.2.3 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
-	go.opentelemetry.io/collector/client v1.34.1 // indirect
+	go.opentelemetry.io/collector/client v1.35.0 // indirect
 	go.opentelemetry.io/collector/config/configmiddleware v0.128.1 // indirect
-	go.opentelemetry.io/collector/config/confignet v1.34.1 // indirect
+	go.opentelemetry.io/collector/config/confignet v1.35.0 // indirect
 	go.opentelemetry.io/collector/consumer/consumererror/xconsumererror v0.128.1 // indirect
 	go.opentelemetry.io/collector/consumer/consumertest v0.128.1 // indirect
 	go.opentelemetry.io/collector/consumer/xconsumer v0.128.1 // indirect
-	go.opentelemetry.io/collector/extension v1.34.1 // indirect
-	go.opentelemetry.io/collector/extension/extensionauth v1.34.1 // indirect
+	go.opentelemetry.io/collector/extension v1.35.0 // indirect
+	go.opentelemetry.io/collector/extension/extensionauth v1.35.0 // indirect
 	go.opentelemetry.io/collector/extension/extensionmiddleware v0.128.1 // indirect
 	go.opentelemetry.io/collector/extension/xextension v0.128.1 // indirect
-	go.opentelemetry.io/collector/featuregate v1.34.1 // indirect
+	go.opentelemetry.io/collector/featuregate v1.35.0 // indirect
 	go.opentelemetry.io/collector/internal/telemetry v0.128.1 // indirect
 	go.opentelemetry.io/collector/pdata/xpdata v0.128.1 // indirect
 	go.opentelemetry.io/collector/pipeline v0.128.1 // indirect
 	go.opentelemetry.io/collector/pipeline/xpipeline v0.128.1 // indirect
-	go.opentelemetry.io/collector/receiver v1.34.1 // indirect
+	go.opentelemetry.io/collector/receiver v1.35.0 // indirect
 	go.opentelemetry.io/collector/receiver/receivertest v0.128.1 // indirect
 	go.opentelemetry.io/collector/receiver/xreceiver v0.128.1 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.11.0 // indirect

--- a/exporter/otlphttpexporter/go.mod
+++ b/exporter/otlphttpexporter/go.mod
@@ -4,24 +4,24 @@ go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0
-	go.opentelemetry.io/collector v0.128.1
+	go.opentelemetry.io/collector v0.129.0
 	go.opentelemetry.io/collector/component v1.35.0
-	go.opentelemetry.io/collector/component/componenttest v0.128.1
+	go.opentelemetry.io/collector/component/componenttest v0.129.0
 	go.opentelemetry.io/collector/config/configcompression v1.35.0
-	go.opentelemetry.io/collector/config/confighttp v0.128.1
+	go.opentelemetry.io/collector/config/confighttp v0.129.0
 	go.opentelemetry.io/collector/config/configopaque v1.35.0
 	go.opentelemetry.io/collector/config/configretry v1.35.0
 	go.opentelemetry.io/collector/config/configtls v1.35.0
 	go.opentelemetry.io/collector/confmap v1.35.0
-	go.opentelemetry.io/collector/confmap/xconfmap v0.128.1
+	go.opentelemetry.io/collector/confmap/xconfmap v0.129.0
 	go.opentelemetry.io/collector/consumer v1.35.0
-	go.opentelemetry.io/collector/consumer/consumererror v0.128.1
-	go.opentelemetry.io/collector/exporter v0.128.1
-	go.opentelemetry.io/collector/exporter/exporterhelper/xexporterhelper v0.128.1
-	go.opentelemetry.io/collector/exporter/exportertest v0.128.1
-	go.opentelemetry.io/collector/exporter/xexporter v0.128.1
+	go.opentelemetry.io/collector/consumer/consumererror v0.129.0
+	go.opentelemetry.io/collector/exporter v0.129.0
+	go.opentelemetry.io/collector/exporter/exporterhelper/xexporterhelper v0.129.0
+	go.opentelemetry.io/collector/exporter/exportertest v0.129.0
+	go.opentelemetry.io/collector/exporter/xexporter v0.129.0
 	go.opentelemetry.io/collector/pdata v1.35.0
-	go.opentelemetry.io/collector/pdata/pprofile v0.128.1
+	go.opentelemetry.io/collector/pdata/pprofile v0.129.0
 	go.uber.org/goleak v1.3.0
 	go.uber.org/zap v1.27.0
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250324211829-b45e905df463
@@ -58,23 +58,23 @@ require (
 	github.com/rs/cors v1.11.1 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/collector/client v1.35.0 // indirect
-	go.opentelemetry.io/collector/config/configauth v0.128.1 // indirect
-	go.opentelemetry.io/collector/config/configmiddleware v0.128.1 // indirect
-	go.opentelemetry.io/collector/consumer/consumererror/xconsumererror v0.128.1 // indirect
-	go.opentelemetry.io/collector/consumer/consumertest v0.128.1 // indirect
-	go.opentelemetry.io/collector/consumer/xconsumer v0.128.1 // indirect
+	go.opentelemetry.io/collector/config/configauth v0.129.0 // indirect
+	go.opentelemetry.io/collector/config/configmiddleware v0.129.0 // indirect
+	go.opentelemetry.io/collector/consumer/consumererror/xconsumererror v0.129.0 // indirect
+	go.opentelemetry.io/collector/consumer/consumertest v0.129.0 // indirect
+	go.opentelemetry.io/collector/consumer/xconsumer v0.129.0 // indirect
 	go.opentelemetry.io/collector/extension v1.35.0 // indirect
 	go.opentelemetry.io/collector/extension/extensionauth v1.35.0 // indirect
-	go.opentelemetry.io/collector/extension/extensionmiddleware v0.128.1 // indirect
-	go.opentelemetry.io/collector/extension/xextension v0.128.1 // indirect
+	go.opentelemetry.io/collector/extension/extensionmiddleware v0.129.0 // indirect
+	go.opentelemetry.io/collector/extension/xextension v0.129.0 // indirect
 	go.opentelemetry.io/collector/featuregate v1.35.0 // indirect
-	go.opentelemetry.io/collector/internal/telemetry v0.128.1 // indirect
-	go.opentelemetry.io/collector/pdata/xpdata v0.128.1 // indirect
-	go.opentelemetry.io/collector/pipeline v0.128.1 // indirect
-	go.opentelemetry.io/collector/pipeline/xpipeline v0.128.1 // indirect
+	go.opentelemetry.io/collector/internal/telemetry v0.129.0 // indirect
+	go.opentelemetry.io/collector/pdata/xpdata v0.129.0 // indirect
+	go.opentelemetry.io/collector/pipeline v0.129.0 // indirect
+	go.opentelemetry.io/collector/pipeline/xpipeline v0.129.0 // indirect
 	go.opentelemetry.io/collector/receiver v1.35.0 // indirect
-	go.opentelemetry.io/collector/receiver/receivertest v0.128.1 // indirect
-	go.opentelemetry.io/collector/receiver/xreceiver v0.128.1 // indirect
+	go.opentelemetry.io/collector/receiver/receivertest v0.129.0 // indirect
+	go.opentelemetry.io/collector/receiver/xreceiver v0.129.0 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.11.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.61.0 // indirect
 	go.opentelemetry.io/otel v1.36.0 // indirect

--- a/exporter/otlphttpexporter/go.mod
+++ b/exporter/otlphttpexporter/go.mod
@@ -5,22 +5,22 @@ go 1.23.0
 require (
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector v0.128.1
-	go.opentelemetry.io/collector/component v1.34.1
+	go.opentelemetry.io/collector/component v1.35.0
 	go.opentelemetry.io/collector/component/componenttest v0.128.1
-	go.opentelemetry.io/collector/config/configcompression v1.34.1
+	go.opentelemetry.io/collector/config/configcompression v1.35.0
 	go.opentelemetry.io/collector/config/confighttp v0.128.1
-	go.opentelemetry.io/collector/config/configopaque v1.34.1
-	go.opentelemetry.io/collector/config/configretry v1.34.1
-	go.opentelemetry.io/collector/config/configtls v1.34.1
-	go.opentelemetry.io/collector/confmap v1.34.1
+	go.opentelemetry.io/collector/config/configopaque v1.35.0
+	go.opentelemetry.io/collector/config/configretry v1.35.0
+	go.opentelemetry.io/collector/config/configtls v1.35.0
+	go.opentelemetry.io/collector/confmap v1.35.0
 	go.opentelemetry.io/collector/confmap/xconfmap v0.128.1
-	go.opentelemetry.io/collector/consumer v1.34.1
+	go.opentelemetry.io/collector/consumer v1.35.0
 	go.opentelemetry.io/collector/consumer/consumererror v0.128.1
 	go.opentelemetry.io/collector/exporter v0.128.1
 	go.opentelemetry.io/collector/exporter/exporterhelper/xexporterhelper v0.128.1
 	go.opentelemetry.io/collector/exporter/exportertest v0.128.1
 	go.opentelemetry.io/collector/exporter/xexporter v0.128.1
-	go.opentelemetry.io/collector/pdata v1.34.1
+	go.opentelemetry.io/collector/pdata v1.35.0
 	go.opentelemetry.io/collector/pdata/pprofile v0.128.1
 	go.uber.org/goleak v1.3.0
 	go.uber.org/zap v1.27.0
@@ -57,22 +57,22 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rs/cors v1.11.1 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
-	go.opentelemetry.io/collector/client v1.34.1 // indirect
+	go.opentelemetry.io/collector/client v1.35.0 // indirect
 	go.opentelemetry.io/collector/config/configauth v0.128.1 // indirect
 	go.opentelemetry.io/collector/config/configmiddleware v0.128.1 // indirect
 	go.opentelemetry.io/collector/consumer/consumererror/xconsumererror v0.128.1 // indirect
 	go.opentelemetry.io/collector/consumer/consumertest v0.128.1 // indirect
 	go.opentelemetry.io/collector/consumer/xconsumer v0.128.1 // indirect
-	go.opentelemetry.io/collector/extension v1.34.1 // indirect
-	go.opentelemetry.io/collector/extension/extensionauth v1.34.1 // indirect
+	go.opentelemetry.io/collector/extension v1.35.0 // indirect
+	go.opentelemetry.io/collector/extension/extensionauth v1.35.0 // indirect
 	go.opentelemetry.io/collector/extension/extensionmiddleware v0.128.1 // indirect
 	go.opentelemetry.io/collector/extension/xextension v0.128.1 // indirect
-	go.opentelemetry.io/collector/featuregate v1.34.1 // indirect
+	go.opentelemetry.io/collector/featuregate v1.35.0 // indirect
 	go.opentelemetry.io/collector/internal/telemetry v0.128.1 // indirect
 	go.opentelemetry.io/collector/pdata/xpdata v0.128.1 // indirect
 	go.opentelemetry.io/collector/pipeline v0.128.1 // indirect
 	go.opentelemetry.io/collector/pipeline/xpipeline v0.128.1 // indirect
-	go.opentelemetry.io/collector/receiver v1.34.1 // indirect
+	go.opentelemetry.io/collector/receiver v1.35.0 // indirect
 	go.opentelemetry.io/collector/receiver/receivertest v0.128.1 // indirect
 	go.opentelemetry.io/collector/receiver/xreceiver v0.128.1 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.11.0 // indirect

--- a/exporter/xexporter/go.mod
+++ b/exporter/xexporter/go.mod
@@ -4,7 +4,7 @@ go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0
-	go.opentelemetry.io/collector/component v1.34.1
+	go.opentelemetry.io/collector/component v1.35.0
 	go.opentelemetry.io/collector/consumer/consumertest v0.128.1
 	go.opentelemetry.io/collector/consumer/xconsumer v0.128.1
 	go.opentelemetry.io/collector/exporter v0.128.1
@@ -23,10 +23,10 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
-	go.opentelemetry.io/collector/consumer v1.34.1 // indirect
-	go.opentelemetry.io/collector/featuregate v1.34.1 // indirect
+	go.opentelemetry.io/collector/consumer v1.35.0 // indirect
+	go.opentelemetry.io/collector/featuregate v1.35.0 // indirect
 	go.opentelemetry.io/collector/internal/telemetry v0.128.1 // indirect
-	go.opentelemetry.io/collector/pdata v1.34.1 // indirect
+	go.opentelemetry.io/collector/pdata v1.35.0 // indirect
 	go.opentelemetry.io/collector/pdata/pprofile v0.128.1 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.11.0 // indirect
 	go.opentelemetry.io/otel v1.36.0 // indirect

--- a/exporter/xexporter/go.mod
+++ b/exporter/xexporter/go.mod
@@ -5,10 +5,10 @@ go 1.23.0
 require (
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/component v1.35.0
-	go.opentelemetry.io/collector/consumer/consumertest v0.128.1
-	go.opentelemetry.io/collector/consumer/xconsumer v0.128.1
-	go.opentelemetry.io/collector/exporter v0.128.1
-	go.opentelemetry.io/collector/pipeline v0.128.1
+	go.opentelemetry.io/collector/consumer/consumertest v0.129.0
+	go.opentelemetry.io/collector/consumer/xconsumer v0.129.0
+	go.opentelemetry.io/collector/exporter v0.129.0
+	go.opentelemetry.io/collector/pipeline v0.129.0
 )
 
 require (
@@ -25,9 +25,9 @@ require (
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/collector/consumer v1.35.0 // indirect
 	go.opentelemetry.io/collector/featuregate v1.35.0 // indirect
-	go.opentelemetry.io/collector/internal/telemetry v0.128.1 // indirect
+	go.opentelemetry.io/collector/internal/telemetry v0.129.0 // indirect
 	go.opentelemetry.io/collector/pdata v1.35.0 // indirect
-	go.opentelemetry.io/collector/pdata/pprofile v0.128.1 // indirect
+	go.opentelemetry.io/collector/pdata/pprofile v0.129.0 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.11.0 // indirect
 	go.opentelemetry.io/otel v1.36.0 // indirect
 	go.opentelemetry.io/otel/log v0.12.2 // indirect

--- a/extension/extensionauth/extensionauthtest/go.mod
+++ b/extension/extensionauth/extensionauthtest/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/collector/featuregate v1.35.0 // indirect
-	go.opentelemetry.io/collector/internal/telemetry v0.128.1 // indirect
+	go.opentelemetry.io/collector/internal/telemetry v0.129.0 // indirect
 	go.opentelemetry.io/collector/pdata v1.35.0 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.11.0 // indirect
 	go.opentelemetry.io/otel v1.36.0 // indirect

--- a/extension/extensionauth/extensionauthtest/go.mod
+++ b/extension/extensionauth/extensionauthtest/go.mod
@@ -4,9 +4,9 @@ go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0
-	go.opentelemetry.io/collector/component v1.34.1
-	go.opentelemetry.io/collector/extension v1.34.1
-	go.opentelemetry.io/collector/extension/extensionauth v1.34.1
+	go.opentelemetry.io/collector/component v1.35.0
+	go.opentelemetry.io/collector/extension v1.35.0
+	go.opentelemetry.io/collector/extension/extensionauth v1.35.0
 	go.uber.org/goleak v1.3.0
 	google.golang.org/grpc v1.73.0
 )
@@ -20,9 +20,9 @@ require (
 	github.com/hashicorp/go-version v1.7.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
-	go.opentelemetry.io/collector/featuregate v1.34.1 // indirect
+	go.opentelemetry.io/collector/featuregate v1.35.0 // indirect
 	go.opentelemetry.io/collector/internal/telemetry v0.128.1 // indirect
-	go.opentelemetry.io/collector/pdata v1.34.1 // indirect
+	go.opentelemetry.io/collector/pdata v1.35.0 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.11.0 // indirect
 	go.opentelemetry.io/otel v1.36.0 // indirect
 	go.opentelemetry.io/otel/log v0.12.2 // indirect

--- a/extension/extensioncapabilities/go.mod
+++ b/extension/extensioncapabilities/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/collector/featuregate v1.35.0 // indirect
-	go.opentelemetry.io/collector/internal/telemetry v0.128.1 // indirect
+	go.opentelemetry.io/collector/internal/telemetry v0.129.0 // indirect
 	go.opentelemetry.io/collector/pdata v1.35.0 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.11.0 // indirect
 	go.opentelemetry.io/otel v1.36.0 // indirect

--- a/extension/extensioncapabilities/go.mod
+++ b/extension/extensioncapabilities/go.mod
@@ -3,9 +3,9 @@ module go.opentelemetry.io/collector/extension/extensioncapabilities
 go 1.23.0
 
 require (
-	go.opentelemetry.io/collector/component v1.34.1
-	go.opentelemetry.io/collector/confmap v1.34.1
-	go.opentelemetry.io/collector/extension v1.34.1
+	go.opentelemetry.io/collector/component v1.35.0
+	go.opentelemetry.io/collector/confmap v1.35.0
+	go.opentelemetry.io/collector/extension v1.35.0
 )
 
 require (
@@ -22,9 +22,9 @@ require (
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
-	go.opentelemetry.io/collector/featuregate v1.34.1 // indirect
+	go.opentelemetry.io/collector/featuregate v1.35.0 // indirect
 	go.opentelemetry.io/collector/internal/telemetry v0.128.1 // indirect
-	go.opentelemetry.io/collector/pdata v1.34.1 // indirect
+	go.opentelemetry.io/collector/pdata v1.35.0 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.11.0 // indirect
 	go.opentelemetry.io/otel v1.36.0 // indirect
 	go.opentelemetry.io/otel/log v0.12.2 // indirect

--- a/extension/extensionmiddleware/extensionmiddlewaretest/go.mod
+++ b/extension/extensionmiddleware/extensionmiddlewaretest/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/component v1.35.0
 	go.opentelemetry.io/collector/extension v1.35.0
-	go.opentelemetry.io/collector/extension/extensionmiddleware v0.128.1
+	go.opentelemetry.io/collector/extension/extensionmiddleware v0.129.0
 	google.golang.org/grpc v1.73.0
 )
 
@@ -20,7 +20,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/collector/featuregate v1.35.0 // indirect
-	go.opentelemetry.io/collector/internal/telemetry v0.128.1 // indirect
+	go.opentelemetry.io/collector/internal/telemetry v0.129.0 // indirect
 	go.opentelemetry.io/collector/pdata v1.35.0 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.11.0 // indirect
 	go.opentelemetry.io/otel v1.36.0 // indirect

--- a/extension/extensionmiddleware/extensionmiddlewaretest/go.mod
+++ b/extension/extensionmiddleware/extensionmiddlewaretest/go.mod
@@ -4,8 +4,8 @@ go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0
-	go.opentelemetry.io/collector/component v1.34.1
-	go.opentelemetry.io/collector/extension v1.34.1
+	go.opentelemetry.io/collector/component v1.35.0
+	go.opentelemetry.io/collector/extension v1.35.0
 	go.opentelemetry.io/collector/extension/extensionmiddleware v0.128.1
 	google.golang.org/grpc v1.73.0
 )
@@ -19,9 +19,9 @@ require (
 	github.com/hashicorp/go-version v1.7.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
-	go.opentelemetry.io/collector/featuregate v1.34.1 // indirect
+	go.opentelemetry.io/collector/featuregate v1.35.0 // indirect
 	go.opentelemetry.io/collector/internal/telemetry v0.128.1 // indirect
-	go.opentelemetry.io/collector/pdata v1.34.1 // indirect
+	go.opentelemetry.io/collector/pdata v1.35.0 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.11.0 // indirect
 	go.opentelemetry.io/otel v1.36.0 // indirect
 	go.opentelemetry.io/otel/log v0.12.2 // indirect

--- a/extension/extensiontest/go.mod
+++ b/extension/extensiontest/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/component v1.35.0
-	go.opentelemetry.io/collector/component/componenttest v0.128.1
+	go.opentelemetry.io/collector/component/componenttest v0.129.0
 	go.opentelemetry.io/collector/extension v1.35.0
 )
 
@@ -21,7 +21,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/collector/featuregate v1.35.0 // indirect
-	go.opentelemetry.io/collector/internal/telemetry v0.128.1 // indirect
+	go.opentelemetry.io/collector/internal/telemetry v0.129.0 // indirect
 	go.opentelemetry.io/collector/pdata v1.35.0 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.11.0 // indirect
 	go.opentelemetry.io/otel v1.36.0 // indirect

--- a/extension/extensiontest/go.mod
+++ b/extension/extensiontest/go.mod
@@ -7,9 +7,9 @@ replace go.opentelemetry.io/collector/extension => ..
 require (
 	github.com/google/uuid v1.6.0
 	github.com/stretchr/testify v1.10.0
-	go.opentelemetry.io/collector/component v1.34.1
+	go.opentelemetry.io/collector/component v1.35.0
 	go.opentelemetry.io/collector/component/componenttest v0.128.1
-	go.opentelemetry.io/collector/extension v1.34.1
+	go.opentelemetry.io/collector/extension v1.35.0
 )
 
 require (
@@ -20,9 +20,9 @@ require (
 	github.com/hashicorp/go-version v1.7.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
-	go.opentelemetry.io/collector/featuregate v1.34.1 // indirect
+	go.opentelemetry.io/collector/featuregate v1.35.0 // indirect
 	go.opentelemetry.io/collector/internal/telemetry v0.128.1 // indirect
-	go.opentelemetry.io/collector/pdata v1.34.1 // indirect
+	go.opentelemetry.io/collector/pdata v1.35.0 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.11.0 // indirect
 	go.opentelemetry.io/otel v1.36.0 // indirect
 	go.opentelemetry.io/otel/log v0.12.2 // indirect

--- a/extension/go.mod
+++ b/extension/go.mod
@@ -4,7 +4,7 @@ go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0
-	go.opentelemetry.io/collector/component v1.34.1
+	go.opentelemetry.io/collector/component v1.35.0
 	go.uber.org/goleak v1.3.0
 )
 
@@ -17,9 +17,9 @@ require (
 	github.com/hashicorp/go-version v1.7.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
-	go.opentelemetry.io/collector/featuregate v1.34.1 // indirect
+	go.opentelemetry.io/collector/featuregate v1.35.0 // indirect
 	go.opentelemetry.io/collector/internal/telemetry v0.128.1 // indirect
-	go.opentelemetry.io/collector/pdata v1.34.1 // indirect
+	go.opentelemetry.io/collector/pdata v1.35.0 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.11.0 // indirect
 	go.opentelemetry.io/otel v1.36.0 // indirect
 	go.opentelemetry.io/otel/log v0.12.2 // indirect

--- a/extension/go.mod
+++ b/extension/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/collector/featuregate v1.35.0 // indirect
-	go.opentelemetry.io/collector/internal/telemetry v0.128.1 // indirect
+	go.opentelemetry.io/collector/internal/telemetry v0.129.0 // indirect
 	go.opentelemetry.io/collector/pdata v1.35.0 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.11.0 // indirect
 	go.opentelemetry.io/otel v1.36.0 // indirect

--- a/extension/memorylimiterextension/go.mod
+++ b/extension/memorylimiterextension/go.mod
@@ -5,11 +5,11 @@ go 1.23.0
 require (
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/component v1.35.0
-	go.opentelemetry.io/collector/component/componenttest v0.128.1
+	go.opentelemetry.io/collector/component/componenttest v0.129.0
 	go.opentelemetry.io/collector/confmap v1.35.0
 	go.opentelemetry.io/collector/extension v1.35.0
-	go.opentelemetry.io/collector/extension/extensiontest v0.128.1
-	go.opentelemetry.io/collector/internal/memorylimiter v0.128.1
+	go.opentelemetry.io/collector/extension/extensiontest v0.129.0
+	go.opentelemetry.io/collector/internal/memorylimiter v0.129.0
 	go.uber.org/goleak v1.3.0
 	go.uber.org/zap v1.27.0
 )
@@ -39,7 +39,7 @@ require (
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/collector/featuregate v1.35.0 // indirect
-	go.opentelemetry.io/collector/internal/telemetry v0.128.1 // indirect
+	go.opentelemetry.io/collector/internal/telemetry v0.129.0 // indirect
 	go.opentelemetry.io/collector/pdata v1.35.0 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.11.0 // indirect
 	go.opentelemetry.io/otel v1.36.0 // indirect

--- a/extension/memorylimiterextension/go.mod
+++ b/extension/memorylimiterextension/go.mod
@@ -4,10 +4,10 @@ go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0
-	go.opentelemetry.io/collector/component v1.34.1
+	go.opentelemetry.io/collector/component v1.35.0
 	go.opentelemetry.io/collector/component/componenttest v0.128.1
-	go.opentelemetry.io/collector/confmap v1.34.1
-	go.opentelemetry.io/collector/extension v1.34.1
+	go.opentelemetry.io/collector/confmap v1.35.0
+	go.opentelemetry.io/collector/extension v1.35.0
 	go.opentelemetry.io/collector/extension/extensiontest v0.128.1
 	go.opentelemetry.io/collector/internal/memorylimiter v0.128.1
 	go.uber.org/goleak v1.3.0
@@ -38,9 +38,9 @@ require (
 	github.com/tklauser/numcpus v0.6.1 // indirect
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
-	go.opentelemetry.io/collector/featuregate v1.34.1 // indirect
+	go.opentelemetry.io/collector/featuregate v1.35.0 // indirect
 	go.opentelemetry.io/collector/internal/telemetry v0.128.1 // indirect
-	go.opentelemetry.io/collector/pdata v1.34.1 // indirect
+	go.opentelemetry.io/collector/pdata v1.35.0 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.11.0 // indirect
 	go.opentelemetry.io/otel v1.36.0 // indirect
 	go.opentelemetry.io/otel/log v0.12.2 // indirect

--- a/extension/xextension/go.mod
+++ b/extension/xextension/go.mod
@@ -3,8 +3,8 @@ module go.opentelemetry.io/collector/extension/xextension
 go 1.23.0
 
 require (
-	go.opentelemetry.io/collector/component v1.34.1
-	go.opentelemetry.io/collector/extension v1.34.1
+	go.opentelemetry.io/collector/component v1.35.0
+	go.opentelemetry.io/collector/extension v1.35.0
 )
 
 require (
@@ -14,9 +14,9 @@ require (
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/hashicorp/go-version v1.7.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
-	go.opentelemetry.io/collector/featuregate v1.34.1 // indirect
+	go.opentelemetry.io/collector/featuregate v1.35.0 // indirect
 	go.opentelemetry.io/collector/internal/telemetry v0.128.1 // indirect
-	go.opentelemetry.io/collector/pdata v1.34.1 // indirect
+	go.opentelemetry.io/collector/pdata v1.35.0 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.11.0 // indirect
 	go.opentelemetry.io/otel v1.36.0 // indirect
 	go.opentelemetry.io/otel/log v0.12.2 // indirect

--- a/extension/xextension/go.mod
+++ b/extension/xextension/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/hashicorp/go-version v1.7.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/collector/featuregate v1.35.0 // indirect
-	go.opentelemetry.io/collector/internal/telemetry v0.128.1 // indirect
+	go.opentelemetry.io/collector/internal/telemetry v0.129.0 // indirect
 	go.opentelemetry.io/collector/pdata v1.35.0 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.11.0 // indirect
 	go.opentelemetry.io/otel v1.36.0 // indirect

--- a/extension/zpagesextension/go.mod
+++ b/extension/zpagesextension/go.mod
@@ -5,13 +5,13 @@ go 1.23.0
 require (
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector v0.128.1
-	go.opentelemetry.io/collector/component v1.34.1
+	go.opentelemetry.io/collector/component v1.35.0
 	go.opentelemetry.io/collector/component/componentstatus v0.128.1
 	go.opentelemetry.io/collector/component/componenttest v0.128.1
 	go.opentelemetry.io/collector/config/configauth v0.128.1
 	go.opentelemetry.io/collector/config/confighttp v0.128.1
-	go.opentelemetry.io/collector/confmap v1.34.1
-	go.opentelemetry.io/collector/extension v1.34.1
+	go.opentelemetry.io/collector/confmap v1.35.0
+	go.opentelemetry.io/collector/extension v1.35.0
 	go.opentelemetry.io/collector/extension/extensiontest v0.128.1
 	go.opentelemetry.io/contrib/zpages v0.61.0
 	go.opentelemetry.io/otel/sdk v1.36.0
@@ -44,16 +44,16 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rs/cors v1.11.1 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
-	go.opentelemetry.io/collector/client v1.34.1 // indirect
-	go.opentelemetry.io/collector/config/configcompression v1.34.1 // indirect
+	go.opentelemetry.io/collector/client v1.35.0 // indirect
+	go.opentelemetry.io/collector/config/configcompression v1.35.0 // indirect
 	go.opentelemetry.io/collector/config/configmiddleware v0.128.1 // indirect
-	go.opentelemetry.io/collector/config/configopaque v1.34.1 // indirect
-	go.opentelemetry.io/collector/config/configtls v1.34.1 // indirect
-	go.opentelemetry.io/collector/extension/extensionauth v1.34.1 // indirect
+	go.opentelemetry.io/collector/config/configopaque v1.35.0 // indirect
+	go.opentelemetry.io/collector/config/configtls v1.35.0 // indirect
+	go.opentelemetry.io/collector/extension/extensionauth v1.35.0 // indirect
 	go.opentelemetry.io/collector/extension/extensionmiddleware v0.128.1 // indirect
-	go.opentelemetry.io/collector/featuregate v1.34.1 // indirect
+	go.opentelemetry.io/collector/featuregate v1.35.0 // indirect
 	go.opentelemetry.io/collector/internal/telemetry v0.128.1 // indirect
-	go.opentelemetry.io/collector/pdata v1.34.1 // indirect
+	go.opentelemetry.io/collector/pdata v1.35.0 // indirect
 	go.opentelemetry.io/collector/pipeline v0.128.1 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.11.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.61.0 // indirect

--- a/extension/zpagesextension/go.mod
+++ b/extension/zpagesextension/go.mod
@@ -4,15 +4,15 @@ go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0
-	go.opentelemetry.io/collector v0.128.1
+	go.opentelemetry.io/collector v0.129.0
 	go.opentelemetry.io/collector/component v1.35.0
-	go.opentelemetry.io/collector/component/componentstatus v0.128.1
-	go.opentelemetry.io/collector/component/componenttest v0.128.1
-	go.opentelemetry.io/collector/config/configauth v0.128.1
-	go.opentelemetry.io/collector/config/confighttp v0.128.1
+	go.opentelemetry.io/collector/component/componentstatus v0.129.0
+	go.opentelemetry.io/collector/component/componenttest v0.129.0
+	go.opentelemetry.io/collector/config/configauth v0.129.0
+	go.opentelemetry.io/collector/config/confighttp v0.129.0
 	go.opentelemetry.io/collector/confmap v1.35.0
 	go.opentelemetry.io/collector/extension v1.35.0
-	go.opentelemetry.io/collector/extension/extensiontest v0.128.1
+	go.opentelemetry.io/collector/extension/extensiontest v0.129.0
 	go.opentelemetry.io/contrib/zpages v0.61.0
 	go.opentelemetry.io/otel/sdk v1.36.0
 	go.opentelemetry.io/otel/trace v1.36.0
@@ -46,15 +46,15 @@ require (
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/collector/client v1.35.0 // indirect
 	go.opentelemetry.io/collector/config/configcompression v1.35.0 // indirect
-	go.opentelemetry.io/collector/config/configmiddleware v0.128.1 // indirect
+	go.opentelemetry.io/collector/config/configmiddleware v0.129.0 // indirect
 	go.opentelemetry.io/collector/config/configopaque v1.35.0 // indirect
 	go.opentelemetry.io/collector/config/configtls v1.35.0 // indirect
 	go.opentelemetry.io/collector/extension/extensionauth v1.35.0 // indirect
-	go.opentelemetry.io/collector/extension/extensionmiddleware v0.128.1 // indirect
+	go.opentelemetry.io/collector/extension/extensionmiddleware v0.129.0 // indirect
 	go.opentelemetry.io/collector/featuregate v1.35.0 // indirect
-	go.opentelemetry.io/collector/internal/telemetry v0.128.1 // indirect
+	go.opentelemetry.io/collector/internal/telemetry v0.129.0 // indirect
 	go.opentelemetry.io/collector/pdata v1.35.0 // indirect
-	go.opentelemetry.io/collector/pipeline v0.128.1 // indirect
+	go.opentelemetry.io/collector/pipeline v0.129.0 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.11.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.61.0 // indirect
 	go.opentelemetry.io/otel v1.36.0 // indirect

--- a/filter/go.mod
+++ b/filter/go.mod
@@ -4,7 +4,7 @@ go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0
-	go.opentelemetry.io/collector/confmap v1.34.1
+	go.opentelemetry.io/collector/confmap v1.35.0
 )
 
 require (
@@ -18,7 +18,7 @@ require (
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	go.opentelemetry.io/collector/featuregate v1.34.1 // indirect
+	go.opentelemetry.io/collector/featuregate v1.35.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.27.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/internal/e2e/go.mod
+++ b/internal/e2e/go.mod
@@ -4,37 +4,37 @@ go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0
-	go.opentelemetry.io/collector v0.128.1
+	go.opentelemetry.io/collector v0.129.0
 	go.opentelemetry.io/collector/component v1.35.0
-	go.opentelemetry.io/collector/component/componentstatus v0.128.1
-	go.opentelemetry.io/collector/component/componenttest v0.128.1
-	go.opentelemetry.io/collector/config/configauth v0.128.1
-	go.opentelemetry.io/collector/config/configgrpc v0.128.1
-	go.opentelemetry.io/collector/config/confighttp v0.128.1
+	go.opentelemetry.io/collector/component/componentstatus v0.129.0
+	go.opentelemetry.io/collector/component/componenttest v0.129.0
+	go.opentelemetry.io/collector/config/configauth v0.129.0
+	go.opentelemetry.io/collector/config/configgrpc v0.129.0
+	go.opentelemetry.io/collector/config/confighttp v0.129.0
 	go.opentelemetry.io/collector/config/confignet v1.35.0
 	go.opentelemetry.io/collector/config/configopaque v1.35.0
-	go.opentelemetry.io/collector/config/configoptional v0.128.1
+	go.opentelemetry.io/collector/config/configoptional v0.129.0
 	go.opentelemetry.io/collector/config/configretry v1.35.0
-	go.opentelemetry.io/collector/config/configtelemetry v0.128.1
+	go.opentelemetry.io/collector/config/configtelemetry v0.129.0
 	go.opentelemetry.io/collector/config/configtls v1.35.0
 	go.opentelemetry.io/collector/confmap v1.35.0
-	go.opentelemetry.io/collector/connector v0.128.1
-	go.opentelemetry.io/collector/connector/connectortest v0.128.1
+	go.opentelemetry.io/collector/connector v0.129.0
+	go.opentelemetry.io/collector/connector/connectortest v0.129.0
 	go.opentelemetry.io/collector/consumer v1.35.0
-	go.opentelemetry.io/collector/consumer/consumertest v0.128.1
-	go.opentelemetry.io/collector/exporter v0.128.1
-	go.opentelemetry.io/collector/exporter/exportertest v0.128.1
-	go.opentelemetry.io/collector/exporter/otlpexporter v0.128.1
-	go.opentelemetry.io/collector/exporter/otlphttpexporter v0.128.1
+	go.opentelemetry.io/collector/consumer/consumertest v0.129.0
+	go.opentelemetry.io/collector/exporter v0.129.0
+	go.opentelemetry.io/collector/exporter/exportertest v0.129.0
+	go.opentelemetry.io/collector/exporter/otlpexporter v0.129.0
+	go.opentelemetry.io/collector/exporter/otlphttpexporter v0.129.0
 	go.opentelemetry.io/collector/extension v1.35.0
-	go.opentelemetry.io/collector/internal/sharedcomponent v0.128.1
+	go.opentelemetry.io/collector/internal/sharedcomponent v0.129.0
 	go.opentelemetry.io/collector/pdata v1.35.0
-	go.opentelemetry.io/collector/pdata/testdata v0.128.1
-	go.opentelemetry.io/collector/pipeline v0.128.1
+	go.opentelemetry.io/collector/pdata/testdata v0.129.0
+	go.opentelemetry.io/collector/pipeline v0.129.0
 	go.opentelemetry.io/collector/receiver v1.35.0
-	go.opentelemetry.io/collector/receiver/otlpreceiver v0.128.1
-	go.opentelemetry.io/collector/receiver/receivertest v0.128.1
-	go.opentelemetry.io/collector/service v0.128.1
+	go.opentelemetry.io/collector/receiver/otlpreceiver v0.129.0
+	go.opentelemetry.io/collector/receiver/receivertest v0.129.0
+	go.opentelemetry.io/collector/service v0.129.0
 	go.uber.org/goleak v1.3.0
 	go.uber.org/zap v1.27.0
 )
@@ -86,30 +86,30 @@ require (
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/collector/client v1.35.0 // indirect
 	go.opentelemetry.io/collector/config/configcompression v1.35.0 // indirect
-	go.opentelemetry.io/collector/config/configmiddleware v0.128.1 // indirect
-	go.opentelemetry.io/collector/connector/xconnector v0.128.1 // indirect
-	go.opentelemetry.io/collector/consumer/consumererror v0.128.1 // indirect
-	go.opentelemetry.io/collector/consumer/consumererror/xconsumererror v0.128.1 // indirect
-	go.opentelemetry.io/collector/consumer/xconsumer v0.128.1 // indirect
-	go.opentelemetry.io/collector/exporter/exporterhelper/xexporterhelper v0.128.1 // indirect
-	go.opentelemetry.io/collector/exporter/xexporter v0.128.1 // indirect
+	go.opentelemetry.io/collector/config/configmiddleware v0.129.0 // indirect
+	go.opentelemetry.io/collector/connector/xconnector v0.129.0 // indirect
+	go.opentelemetry.io/collector/consumer/consumererror v0.129.0 // indirect
+	go.opentelemetry.io/collector/consumer/consumererror/xconsumererror v0.129.0 // indirect
+	go.opentelemetry.io/collector/consumer/xconsumer v0.129.0 // indirect
+	go.opentelemetry.io/collector/exporter/exporterhelper/xexporterhelper v0.129.0 // indirect
+	go.opentelemetry.io/collector/exporter/xexporter v0.129.0 // indirect
 	go.opentelemetry.io/collector/extension/extensionauth v1.35.0 // indirect
-	go.opentelemetry.io/collector/extension/extensioncapabilities v0.128.1 // indirect
-	go.opentelemetry.io/collector/extension/extensionmiddleware v0.128.1 // indirect
-	go.opentelemetry.io/collector/extension/extensiontest v0.128.1 // indirect
-	go.opentelemetry.io/collector/extension/xextension v0.128.1 // indirect
+	go.opentelemetry.io/collector/extension/extensioncapabilities v0.129.0 // indirect
+	go.opentelemetry.io/collector/extension/extensionmiddleware v0.129.0 // indirect
+	go.opentelemetry.io/collector/extension/extensiontest v0.129.0 // indirect
+	go.opentelemetry.io/collector/extension/xextension v0.129.0 // indirect
 	go.opentelemetry.io/collector/featuregate v1.35.0 // indirect
-	go.opentelemetry.io/collector/internal/fanoutconsumer v0.128.1 // indirect
-	go.opentelemetry.io/collector/internal/telemetry v0.128.1 // indirect
-	go.opentelemetry.io/collector/pdata/pprofile v0.128.1 // indirect
-	go.opentelemetry.io/collector/pdata/xpdata v0.128.1 // indirect
-	go.opentelemetry.io/collector/pipeline/xpipeline v0.128.1 // indirect
+	go.opentelemetry.io/collector/internal/fanoutconsumer v0.129.0 // indirect
+	go.opentelemetry.io/collector/internal/telemetry v0.129.0 // indirect
+	go.opentelemetry.io/collector/pdata/pprofile v0.129.0 // indirect
+	go.opentelemetry.io/collector/pdata/xpdata v0.129.0 // indirect
+	go.opentelemetry.io/collector/pipeline/xpipeline v0.129.0 // indirect
 	go.opentelemetry.io/collector/processor v1.35.0 // indirect
-	go.opentelemetry.io/collector/processor/processortest v0.128.1 // indirect
-	go.opentelemetry.io/collector/processor/xprocessor v0.128.1 // indirect
-	go.opentelemetry.io/collector/receiver/receiverhelper v0.128.1 // indirect
-	go.opentelemetry.io/collector/receiver/xreceiver v0.128.1 // indirect
-	go.opentelemetry.io/collector/service/hostcapabilities v0.128.1 // indirect
+	go.opentelemetry.io/collector/processor/processortest v0.129.0 // indirect
+	go.opentelemetry.io/collector/processor/xprocessor v0.129.0 // indirect
+	go.opentelemetry.io/collector/receiver/receiverhelper v0.129.0 // indirect
+	go.opentelemetry.io/collector/receiver/xreceiver v0.129.0 // indirect
+	go.opentelemetry.io/collector/service/hostcapabilities v0.129.0 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.11.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.61.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.61.0 // indirect

--- a/internal/e2e/go.mod
+++ b/internal/e2e/go.mod
@@ -5,33 +5,33 @@ go 1.23.0
 require (
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector v0.128.1
-	go.opentelemetry.io/collector/component v1.34.1
+	go.opentelemetry.io/collector/component v1.35.0
 	go.opentelemetry.io/collector/component/componentstatus v0.128.1
 	go.opentelemetry.io/collector/component/componenttest v0.128.1
 	go.opentelemetry.io/collector/config/configauth v0.128.1
 	go.opentelemetry.io/collector/config/configgrpc v0.128.1
 	go.opentelemetry.io/collector/config/confighttp v0.128.1
-	go.opentelemetry.io/collector/config/confignet v1.34.1
-	go.opentelemetry.io/collector/config/configopaque v1.34.1
+	go.opentelemetry.io/collector/config/confignet v1.35.0
+	go.opentelemetry.io/collector/config/configopaque v1.35.0
 	go.opentelemetry.io/collector/config/configoptional v0.128.1
-	go.opentelemetry.io/collector/config/configretry v1.34.1
+	go.opentelemetry.io/collector/config/configretry v1.35.0
 	go.opentelemetry.io/collector/config/configtelemetry v0.128.1
-	go.opentelemetry.io/collector/config/configtls v1.34.1
-	go.opentelemetry.io/collector/confmap v1.34.1
+	go.opentelemetry.io/collector/config/configtls v1.35.0
+	go.opentelemetry.io/collector/confmap v1.35.0
 	go.opentelemetry.io/collector/connector v0.128.1
 	go.opentelemetry.io/collector/connector/connectortest v0.128.1
-	go.opentelemetry.io/collector/consumer v1.34.1
+	go.opentelemetry.io/collector/consumer v1.35.0
 	go.opentelemetry.io/collector/consumer/consumertest v0.128.1
 	go.opentelemetry.io/collector/exporter v0.128.1
 	go.opentelemetry.io/collector/exporter/exportertest v0.128.1
 	go.opentelemetry.io/collector/exporter/otlpexporter v0.128.1
 	go.opentelemetry.io/collector/exporter/otlphttpexporter v0.128.1
-	go.opentelemetry.io/collector/extension v1.34.1
+	go.opentelemetry.io/collector/extension v1.35.0
 	go.opentelemetry.io/collector/internal/sharedcomponent v0.128.1
-	go.opentelemetry.io/collector/pdata v1.34.1
+	go.opentelemetry.io/collector/pdata v1.35.0
 	go.opentelemetry.io/collector/pdata/testdata v0.128.1
 	go.opentelemetry.io/collector/pipeline v0.128.1
-	go.opentelemetry.io/collector/receiver v1.34.1
+	go.opentelemetry.io/collector/receiver v1.35.0
 	go.opentelemetry.io/collector/receiver/otlpreceiver v0.128.1
 	go.opentelemetry.io/collector/receiver/receivertest v0.128.1
 	go.opentelemetry.io/collector/service v0.128.1
@@ -84,8 +84,8 @@ require (
 	github.com/tklauser/numcpus v0.6.1 // indirect
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
-	go.opentelemetry.io/collector/client v1.34.1 // indirect
-	go.opentelemetry.io/collector/config/configcompression v1.34.1 // indirect
+	go.opentelemetry.io/collector/client v1.35.0 // indirect
+	go.opentelemetry.io/collector/config/configcompression v1.35.0 // indirect
 	go.opentelemetry.io/collector/config/configmiddleware v0.128.1 // indirect
 	go.opentelemetry.io/collector/connector/xconnector v0.128.1 // indirect
 	go.opentelemetry.io/collector/consumer/consumererror v0.128.1 // indirect
@@ -93,18 +93,18 @@ require (
 	go.opentelemetry.io/collector/consumer/xconsumer v0.128.1 // indirect
 	go.opentelemetry.io/collector/exporter/exporterhelper/xexporterhelper v0.128.1 // indirect
 	go.opentelemetry.io/collector/exporter/xexporter v0.128.1 // indirect
-	go.opentelemetry.io/collector/extension/extensionauth v1.34.1 // indirect
+	go.opentelemetry.io/collector/extension/extensionauth v1.35.0 // indirect
 	go.opentelemetry.io/collector/extension/extensioncapabilities v0.128.1 // indirect
 	go.opentelemetry.io/collector/extension/extensionmiddleware v0.128.1 // indirect
 	go.opentelemetry.io/collector/extension/extensiontest v0.128.1 // indirect
 	go.opentelemetry.io/collector/extension/xextension v0.128.1 // indirect
-	go.opentelemetry.io/collector/featuregate v1.34.1 // indirect
+	go.opentelemetry.io/collector/featuregate v1.35.0 // indirect
 	go.opentelemetry.io/collector/internal/fanoutconsumer v0.128.1 // indirect
 	go.opentelemetry.io/collector/internal/telemetry v0.128.1 // indirect
 	go.opentelemetry.io/collector/pdata/pprofile v0.128.1 // indirect
 	go.opentelemetry.io/collector/pdata/xpdata v0.128.1 // indirect
 	go.opentelemetry.io/collector/pipeline/xpipeline v0.128.1 // indirect
-	go.opentelemetry.io/collector/processor v1.34.1 // indirect
+	go.opentelemetry.io/collector/processor v1.35.0 // indirect
 	go.opentelemetry.io/collector/processor/processortest v0.128.1 // indirect
 	go.opentelemetry.io/collector/processor/xprocessor v0.128.1 // indirect
 	go.opentelemetry.io/collector/receiver/receiverhelper v0.128.1 // indirect

--- a/internal/fanoutconsumer/go.mod
+++ b/internal/fanoutconsumer/go.mod
@@ -4,10 +4,10 @@ go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0
-	go.opentelemetry.io/collector/consumer v1.34.1
+	go.opentelemetry.io/collector/consumer v1.35.0
 	go.opentelemetry.io/collector/consumer/consumertest v0.128.1
 	go.opentelemetry.io/collector/consumer/xconsumer v0.128.1
-	go.opentelemetry.io/collector/pdata v1.34.1
+	go.opentelemetry.io/collector/pdata v1.35.0
 	go.opentelemetry.io/collector/pdata/pprofile v0.128.1
 	go.opentelemetry.io/collector/pdata/testdata v0.128.1
 	go.uber.org/goleak v1.3.0

--- a/internal/fanoutconsumer/go.mod
+++ b/internal/fanoutconsumer/go.mod
@@ -5,11 +5,11 @@ go 1.23.0
 require (
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/consumer v1.35.0
-	go.opentelemetry.io/collector/consumer/consumertest v0.128.1
-	go.opentelemetry.io/collector/consumer/xconsumer v0.128.1
+	go.opentelemetry.io/collector/consumer/consumertest v0.129.0
+	go.opentelemetry.io/collector/consumer/xconsumer v0.129.0
 	go.opentelemetry.io/collector/pdata v1.35.0
-	go.opentelemetry.io/collector/pdata/pprofile v0.128.1
-	go.opentelemetry.io/collector/pdata/testdata v0.128.1
+	go.opentelemetry.io/collector/pdata/pprofile v0.129.0
+	go.opentelemetry.io/collector/pdata/testdata v0.129.0
 	go.uber.org/goleak v1.3.0
 	go.uber.org/multierr v1.11.0
 )

--- a/internal/memorylimiter/go.mod
+++ b/internal/memorylimiter/go.mod
@@ -35,7 +35,7 @@ require (
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/collector/featuregate v1.35.0 // indirect
-	go.opentelemetry.io/collector/internal/telemetry v0.128.1 // indirect
+	go.opentelemetry.io/collector/internal/telemetry v0.129.0 // indirect
 	go.opentelemetry.io/collector/pdata v1.35.0 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.11.0 // indirect
 	go.opentelemetry.io/otel v1.36.0 // indirect

--- a/internal/memorylimiter/go.mod
+++ b/internal/memorylimiter/go.mod
@@ -5,8 +5,8 @@ go 1.23.0
 require (
 	github.com/shirou/gopsutil/v4 v4.25.5
 	github.com/stretchr/testify v1.10.0
-	go.opentelemetry.io/collector/component v1.34.1
-	go.opentelemetry.io/collector/confmap v1.34.1
+	go.opentelemetry.io/collector/component v1.35.0
+	go.opentelemetry.io/collector/confmap v1.35.0
 	go.uber.org/goleak v1.3.0
 	go.uber.org/zap v1.27.0
 )
@@ -34,9 +34,9 @@ require (
 	github.com/tklauser/numcpus v0.6.1 // indirect
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
-	go.opentelemetry.io/collector/featuregate v1.34.1 // indirect
+	go.opentelemetry.io/collector/featuregate v1.35.0 // indirect
 	go.opentelemetry.io/collector/internal/telemetry v0.128.1 // indirect
-	go.opentelemetry.io/collector/pdata v1.34.1 // indirect
+	go.opentelemetry.io/collector/pdata v1.35.0 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.11.0 // indirect
 	go.opentelemetry.io/otel v1.36.0 // indirect
 	go.opentelemetry.io/otel/log v0.12.2 // indirect

--- a/internal/sharedcomponent/go.mod
+++ b/internal/sharedcomponent/go.mod
@@ -5,8 +5,8 @@ go 1.23.0
 require (
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/component v1.35.0
-	go.opentelemetry.io/collector/component/componentstatus v0.128.1
-	go.opentelemetry.io/collector/component/componenttest v0.128.1
+	go.opentelemetry.io/collector/component/componentstatus v0.129.0
+	go.opentelemetry.io/collector/component/componenttest v0.129.0
 	go.uber.org/goleak v1.3.0
 )
 
@@ -20,9 +20,9 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/collector/featuregate v1.35.0 // indirect
-	go.opentelemetry.io/collector/internal/telemetry v0.128.1 // indirect
+	go.opentelemetry.io/collector/internal/telemetry v0.129.0 // indirect
 	go.opentelemetry.io/collector/pdata v1.35.0 // indirect
-	go.opentelemetry.io/collector/pipeline v0.128.1 // indirect
+	go.opentelemetry.io/collector/pipeline v0.129.0 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.11.0 // indirect
 	go.opentelemetry.io/otel v1.36.0 // indirect
 	go.opentelemetry.io/otel/log v0.12.2 // indirect

--- a/internal/sharedcomponent/go.mod
+++ b/internal/sharedcomponent/go.mod
@@ -4,7 +4,7 @@ go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0
-	go.opentelemetry.io/collector/component v1.34.1
+	go.opentelemetry.io/collector/component v1.35.0
 	go.opentelemetry.io/collector/component/componentstatus v0.128.1
 	go.opentelemetry.io/collector/component/componenttest v0.128.1
 	go.uber.org/goleak v1.3.0
@@ -19,9 +19,9 @@ require (
 	github.com/hashicorp/go-version v1.7.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
-	go.opentelemetry.io/collector/featuregate v1.34.1 // indirect
+	go.opentelemetry.io/collector/featuregate v1.35.0 // indirect
 	go.opentelemetry.io/collector/internal/telemetry v0.128.1 // indirect
-	go.opentelemetry.io/collector/pdata v1.34.1 // indirect
+	go.opentelemetry.io/collector/pdata v1.35.0 // indirect
 	go.opentelemetry.io/collector/pipeline v0.128.1 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.11.0 // indirect
 	go.opentelemetry.io/otel v1.36.0 // indirect

--- a/internal/telemetry/go.mod
+++ b/internal/telemetry/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/featuregate v1.35.0
 	go.opentelemetry.io/collector/pdata v1.35.0
-	go.opentelemetry.io/collector/pipeline v0.128.1
+	go.opentelemetry.io/collector/pipeline v0.129.0
 	go.opentelemetry.io/contrib/bridges/otelzap v0.11.0
 	go.opentelemetry.io/otel v1.36.0
 	go.opentelemetry.io/otel/log v0.12.2

--- a/internal/telemetry/go.mod
+++ b/internal/telemetry/go.mod
@@ -4,8 +4,8 @@ go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0
-	go.opentelemetry.io/collector/featuregate v1.34.1
-	go.opentelemetry.io/collector/pdata v1.34.1
+	go.opentelemetry.io/collector/featuregate v1.35.0
+	go.opentelemetry.io/collector/pdata v1.35.0
 	go.opentelemetry.io/collector/pipeline v0.128.1
 	go.opentelemetry.io/contrib/bridges/otelzap v0.11.0
 	go.opentelemetry.io/otel v1.36.0

--- a/otelcol/go.mod
+++ b/otelcol/go.mod
@@ -6,25 +6,25 @@ require (
 	github.com/spf13/cobra v1.9.1
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/component v1.35.0
-	go.opentelemetry.io/collector/component/componentstatus v0.128.1
-	go.opentelemetry.io/collector/config/configtelemetry v0.128.1
+	go.opentelemetry.io/collector/component/componentstatus v0.129.0
+	go.opentelemetry.io/collector/config/configtelemetry v0.129.0
 	go.opentelemetry.io/collector/confmap v1.35.0
 	go.opentelemetry.io/collector/confmap/provider/fileprovider v1.35.0
 	go.opentelemetry.io/collector/confmap/provider/yamlprovider v1.35.0
-	go.opentelemetry.io/collector/confmap/xconfmap v0.128.1
-	go.opentelemetry.io/collector/connector v0.128.1
-	go.opentelemetry.io/collector/connector/connectortest v0.128.1
-	go.opentelemetry.io/collector/exporter v0.128.1
-	go.opentelemetry.io/collector/exporter/exportertest v0.128.1
+	go.opentelemetry.io/collector/confmap/xconfmap v0.129.0
+	go.opentelemetry.io/collector/connector v0.129.0
+	go.opentelemetry.io/collector/connector/connectortest v0.129.0
+	go.opentelemetry.io/collector/exporter v0.129.0
+	go.opentelemetry.io/collector/exporter/exportertest v0.129.0
 	go.opentelemetry.io/collector/extension v1.35.0
-	go.opentelemetry.io/collector/extension/extensiontest v0.128.1
+	go.opentelemetry.io/collector/extension/extensiontest v0.129.0
 	go.opentelemetry.io/collector/featuregate v1.35.0
-	go.opentelemetry.io/collector/pipeline v0.128.1
+	go.opentelemetry.io/collector/pipeline v0.129.0
 	go.opentelemetry.io/collector/processor v1.35.0
-	go.opentelemetry.io/collector/processor/processortest v0.128.1
+	go.opentelemetry.io/collector/processor/processortest v0.129.0
 	go.opentelemetry.io/collector/receiver v1.35.0
-	go.opentelemetry.io/collector/receiver/receivertest v0.128.1
-	go.opentelemetry.io/collector/service v0.128.1
+	go.opentelemetry.io/collector/receiver/receivertest v0.129.0
+	go.opentelemetry.io/collector/service v0.129.0
 	go.opentelemetry.io/contrib/otelconf v0.16.0
 	go.uber.org/goleak v1.3.0
 	go.uber.org/multierr v1.11.0
@@ -73,23 +73,23 @@ require (
 	github.com/tklauser/numcpus v0.6.1 // indirect
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
-	go.opentelemetry.io/collector/component/componenttest v0.128.1 // indirect
-	go.opentelemetry.io/collector/connector/xconnector v0.128.1 // indirect
+	go.opentelemetry.io/collector/component/componenttest v0.129.0 // indirect
+	go.opentelemetry.io/collector/connector/xconnector v0.129.0 // indirect
 	go.opentelemetry.io/collector/consumer v1.35.0 // indirect
-	go.opentelemetry.io/collector/consumer/consumererror v0.128.1 // indirect
-	go.opentelemetry.io/collector/consumer/consumertest v0.128.1 // indirect
-	go.opentelemetry.io/collector/consumer/xconsumer v0.128.1 // indirect
-	go.opentelemetry.io/collector/exporter/xexporter v0.128.1 // indirect
-	go.opentelemetry.io/collector/extension/extensioncapabilities v0.128.1 // indirect
-	go.opentelemetry.io/collector/internal/fanoutconsumer v0.128.1 // indirect
-	go.opentelemetry.io/collector/internal/telemetry v0.128.1 // indirect
+	go.opentelemetry.io/collector/consumer/consumererror v0.129.0 // indirect
+	go.opentelemetry.io/collector/consumer/consumertest v0.129.0 // indirect
+	go.opentelemetry.io/collector/consumer/xconsumer v0.129.0 // indirect
+	go.opentelemetry.io/collector/exporter/xexporter v0.129.0 // indirect
+	go.opentelemetry.io/collector/extension/extensioncapabilities v0.129.0 // indirect
+	go.opentelemetry.io/collector/internal/fanoutconsumer v0.129.0 // indirect
+	go.opentelemetry.io/collector/internal/telemetry v0.129.0 // indirect
 	go.opentelemetry.io/collector/pdata v1.35.0 // indirect
-	go.opentelemetry.io/collector/pdata/pprofile v0.128.1 // indirect
-	go.opentelemetry.io/collector/pdata/testdata v0.128.1 // indirect
-	go.opentelemetry.io/collector/pipeline/xpipeline v0.128.1 // indirect
-	go.opentelemetry.io/collector/processor/xprocessor v0.128.1 // indirect
-	go.opentelemetry.io/collector/receiver/xreceiver v0.128.1 // indirect
-	go.opentelemetry.io/collector/service/hostcapabilities v0.128.1 // indirect
+	go.opentelemetry.io/collector/pdata/pprofile v0.129.0 // indirect
+	go.opentelemetry.io/collector/pdata/testdata v0.129.0 // indirect
+	go.opentelemetry.io/collector/pipeline/xpipeline v0.129.0 // indirect
+	go.opentelemetry.io/collector/processor/xprocessor v0.129.0 // indirect
+	go.opentelemetry.io/collector/receiver/xreceiver v0.129.0 // indirect
+	go.opentelemetry.io/collector/service/hostcapabilities v0.129.0 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.11.0 // indirect
 	go.opentelemetry.io/contrib/propagators/b3 v1.36.0 // indirect
 	go.opentelemetry.io/otel v1.36.0 // indirect

--- a/otelcol/go.mod
+++ b/otelcol/go.mod
@@ -5,24 +5,24 @@ go 1.23.0
 require (
 	github.com/spf13/cobra v1.9.1
 	github.com/stretchr/testify v1.10.0
-	go.opentelemetry.io/collector/component v1.34.1
+	go.opentelemetry.io/collector/component v1.35.0
 	go.opentelemetry.io/collector/component/componentstatus v0.128.1
 	go.opentelemetry.io/collector/config/configtelemetry v0.128.1
-	go.opentelemetry.io/collector/confmap v1.34.1
-	go.opentelemetry.io/collector/confmap/provider/fileprovider v1.34.1
-	go.opentelemetry.io/collector/confmap/provider/yamlprovider v1.34.1
+	go.opentelemetry.io/collector/confmap v1.35.0
+	go.opentelemetry.io/collector/confmap/provider/fileprovider v1.35.0
+	go.opentelemetry.io/collector/confmap/provider/yamlprovider v1.35.0
 	go.opentelemetry.io/collector/confmap/xconfmap v0.128.1
 	go.opentelemetry.io/collector/connector v0.128.1
 	go.opentelemetry.io/collector/connector/connectortest v0.128.1
 	go.opentelemetry.io/collector/exporter v0.128.1
 	go.opentelemetry.io/collector/exporter/exportertest v0.128.1
-	go.opentelemetry.io/collector/extension v1.34.1
+	go.opentelemetry.io/collector/extension v1.35.0
 	go.opentelemetry.io/collector/extension/extensiontest v0.128.1
-	go.opentelemetry.io/collector/featuregate v1.34.1
+	go.opentelemetry.io/collector/featuregate v1.35.0
 	go.opentelemetry.io/collector/pipeline v0.128.1
-	go.opentelemetry.io/collector/processor v1.34.1
+	go.opentelemetry.io/collector/processor v1.35.0
 	go.opentelemetry.io/collector/processor/processortest v0.128.1
-	go.opentelemetry.io/collector/receiver v1.34.1
+	go.opentelemetry.io/collector/receiver v1.35.0
 	go.opentelemetry.io/collector/receiver/receivertest v0.128.1
 	go.opentelemetry.io/collector/service v0.128.1
 	go.opentelemetry.io/contrib/otelconf v0.16.0
@@ -75,7 +75,7 @@ require (
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/collector/component/componenttest v0.128.1 // indirect
 	go.opentelemetry.io/collector/connector/xconnector v0.128.1 // indirect
-	go.opentelemetry.io/collector/consumer v1.34.1 // indirect
+	go.opentelemetry.io/collector/consumer v1.35.0 // indirect
 	go.opentelemetry.io/collector/consumer/consumererror v0.128.1 // indirect
 	go.opentelemetry.io/collector/consumer/consumertest v0.128.1 // indirect
 	go.opentelemetry.io/collector/consumer/xconsumer v0.128.1 // indirect
@@ -83,7 +83,7 @@ require (
 	go.opentelemetry.io/collector/extension/extensioncapabilities v0.128.1 // indirect
 	go.opentelemetry.io/collector/internal/fanoutconsumer v0.128.1 // indirect
 	go.opentelemetry.io/collector/internal/telemetry v0.128.1 // indirect
-	go.opentelemetry.io/collector/pdata v1.34.1 // indirect
+	go.opentelemetry.io/collector/pdata v1.35.0 // indirect
 	go.opentelemetry.io/collector/pdata/pprofile v0.128.1 // indirect
 	go.opentelemetry.io/collector/pdata/testdata v0.128.1 // indirect
 	go.opentelemetry.io/collector/pipeline/xpipeline v0.128.1 // indirect

--- a/otelcol/otelcoltest/go.mod
+++ b/otelcol/otelcoltest/go.mod
@@ -4,12 +4,12 @@ go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0
-	go.opentelemetry.io/collector/component v1.34.1
-	go.opentelemetry.io/collector/confmap v1.34.1
-	go.opentelemetry.io/collector/confmap/provider/envprovider v1.34.1
-	go.opentelemetry.io/collector/confmap/provider/fileprovider v1.34.1
-	go.opentelemetry.io/collector/confmap/provider/httpprovider v1.34.1
-	go.opentelemetry.io/collector/confmap/provider/yamlprovider v1.34.1
+	go.opentelemetry.io/collector/component v1.35.0
+	go.opentelemetry.io/collector/confmap v1.35.0
+	go.opentelemetry.io/collector/confmap/provider/envprovider v1.35.0
+	go.opentelemetry.io/collector/confmap/provider/fileprovider v1.35.0
+	go.opentelemetry.io/collector/confmap/provider/httpprovider v1.35.0
+	go.opentelemetry.io/collector/confmap/provider/yamlprovider v1.35.0
 	go.opentelemetry.io/collector/confmap/xconfmap v0.128.1
 	go.opentelemetry.io/collector/connector/connectortest v0.128.1
 	go.opentelemetry.io/collector/exporter/exportertest v0.128.1
@@ -66,24 +66,24 @@ require (
 	go.opentelemetry.io/collector/config/configtelemetry v0.128.1 // indirect
 	go.opentelemetry.io/collector/connector v0.128.1 // indirect
 	go.opentelemetry.io/collector/connector/xconnector v0.128.1 // indirect
-	go.opentelemetry.io/collector/consumer v1.34.1 // indirect
+	go.opentelemetry.io/collector/consumer v1.35.0 // indirect
 	go.opentelemetry.io/collector/consumer/consumererror v0.128.1 // indirect
 	go.opentelemetry.io/collector/consumer/consumertest v0.128.1 // indirect
 	go.opentelemetry.io/collector/consumer/xconsumer v0.128.1 // indirect
 	go.opentelemetry.io/collector/exporter v0.128.1 // indirect
 	go.opentelemetry.io/collector/exporter/xexporter v0.128.1 // indirect
-	go.opentelemetry.io/collector/extension v1.34.1 // indirect
+	go.opentelemetry.io/collector/extension v1.35.0 // indirect
 	go.opentelemetry.io/collector/extension/extensioncapabilities v0.128.1 // indirect
-	go.opentelemetry.io/collector/featuregate v1.34.1 // indirect
+	go.opentelemetry.io/collector/featuregate v1.35.0 // indirect
 	go.opentelemetry.io/collector/internal/fanoutconsumer v0.128.1 // indirect
 	go.opentelemetry.io/collector/internal/telemetry v0.128.1 // indirect
-	go.opentelemetry.io/collector/pdata v1.34.1 // indirect
+	go.opentelemetry.io/collector/pdata v1.35.0 // indirect
 	go.opentelemetry.io/collector/pdata/pprofile v0.128.1 // indirect
 	go.opentelemetry.io/collector/pdata/testdata v0.128.1 // indirect
 	go.opentelemetry.io/collector/pipeline/xpipeline v0.128.1 // indirect
-	go.opentelemetry.io/collector/processor v1.34.1 // indirect
+	go.opentelemetry.io/collector/processor v1.35.0 // indirect
 	go.opentelemetry.io/collector/processor/xprocessor v0.128.1 // indirect
-	go.opentelemetry.io/collector/receiver v1.34.1 // indirect
+	go.opentelemetry.io/collector/receiver v1.35.0 // indirect
 	go.opentelemetry.io/collector/receiver/xreceiver v0.128.1 // indirect
 	go.opentelemetry.io/collector/service/hostcapabilities v0.128.1 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.11.0 // indirect

--- a/otelcol/otelcoltest/go.mod
+++ b/otelcol/otelcoltest/go.mod
@@ -10,15 +10,15 @@ require (
 	go.opentelemetry.io/collector/confmap/provider/fileprovider v1.35.0
 	go.opentelemetry.io/collector/confmap/provider/httpprovider v1.35.0
 	go.opentelemetry.io/collector/confmap/provider/yamlprovider v1.35.0
-	go.opentelemetry.io/collector/confmap/xconfmap v0.128.1
-	go.opentelemetry.io/collector/connector/connectortest v0.128.1
-	go.opentelemetry.io/collector/exporter/exportertest v0.128.1
-	go.opentelemetry.io/collector/extension/extensiontest v0.128.1
-	go.opentelemetry.io/collector/otelcol v0.128.1
-	go.opentelemetry.io/collector/pipeline v0.128.1
-	go.opentelemetry.io/collector/processor/processortest v0.128.1
-	go.opentelemetry.io/collector/receiver/receivertest v0.128.1
-	go.opentelemetry.io/collector/service v0.128.1
+	go.opentelemetry.io/collector/confmap/xconfmap v0.129.0
+	go.opentelemetry.io/collector/connector/connectortest v0.129.0
+	go.opentelemetry.io/collector/exporter/exportertest v0.129.0
+	go.opentelemetry.io/collector/extension/extensiontest v0.129.0
+	go.opentelemetry.io/collector/otelcol v0.129.0
+	go.opentelemetry.io/collector/pipeline v0.129.0
+	go.opentelemetry.io/collector/processor/processortest v0.129.0
+	go.opentelemetry.io/collector/receiver/receivertest v0.129.0
+	go.opentelemetry.io/collector/service v0.129.0
 	go.uber.org/goleak v1.3.0
 )
 
@@ -61,31 +61,31 @@ require (
 	github.com/tklauser/numcpus v0.6.1 // indirect
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
-	go.opentelemetry.io/collector/component/componentstatus v0.128.1 // indirect
-	go.opentelemetry.io/collector/component/componenttest v0.128.1 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.128.1 // indirect
-	go.opentelemetry.io/collector/connector v0.128.1 // indirect
-	go.opentelemetry.io/collector/connector/xconnector v0.128.1 // indirect
+	go.opentelemetry.io/collector/component/componentstatus v0.129.0 // indirect
+	go.opentelemetry.io/collector/component/componenttest v0.129.0 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.129.0 // indirect
+	go.opentelemetry.io/collector/connector v0.129.0 // indirect
+	go.opentelemetry.io/collector/connector/xconnector v0.129.0 // indirect
 	go.opentelemetry.io/collector/consumer v1.35.0 // indirect
-	go.opentelemetry.io/collector/consumer/consumererror v0.128.1 // indirect
-	go.opentelemetry.io/collector/consumer/consumertest v0.128.1 // indirect
-	go.opentelemetry.io/collector/consumer/xconsumer v0.128.1 // indirect
-	go.opentelemetry.io/collector/exporter v0.128.1 // indirect
-	go.opentelemetry.io/collector/exporter/xexporter v0.128.1 // indirect
+	go.opentelemetry.io/collector/consumer/consumererror v0.129.0 // indirect
+	go.opentelemetry.io/collector/consumer/consumertest v0.129.0 // indirect
+	go.opentelemetry.io/collector/consumer/xconsumer v0.129.0 // indirect
+	go.opentelemetry.io/collector/exporter v0.129.0 // indirect
+	go.opentelemetry.io/collector/exporter/xexporter v0.129.0 // indirect
 	go.opentelemetry.io/collector/extension v1.35.0 // indirect
-	go.opentelemetry.io/collector/extension/extensioncapabilities v0.128.1 // indirect
+	go.opentelemetry.io/collector/extension/extensioncapabilities v0.129.0 // indirect
 	go.opentelemetry.io/collector/featuregate v1.35.0 // indirect
-	go.opentelemetry.io/collector/internal/fanoutconsumer v0.128.1 // indirect
-	go.opentelemetry.io/collector/internal/telemetry v0.128.1 // indirect
+	go.opentelemetry.io/collector/internal/fanoutconsumer v0.129.0 // indirect
+	go.opentelemetry.io/collector/internal/telemetry v0.129.0 // indirect
 	go.opentelemetry.io/collector/pdata v1.35.0 // indirect
-	go.opentelemetry.io/collector/pdata/pprofile v0.128.1 // indirect
-	go.opentelemetry.io/collector/pdata/testdata v0.128.1 // indirect
-	go.opentelemetry.io/collector/pipeline/xpipeline v0.128.1 // indirect
+	go.opentelemetry.io/collector/pdata/pprofile v0.129.0 // indirect
+	go.opentelemetry.io/collector/pdata/testdata v0.129.0 // indirect
+	go.opentelemetry.io/collector/pipeline/xpipeline v0.129.0 // indirect
 	go.opentelemetry.io/collector/processor v1.35.0 // indirect
-	go.opentelemetry.io/collector/processor/xprocessor v0.128.1 // indirect
+	go.opentelemetry.io/collector/processor/xprocessor v0.129.0 // indirect
 	go.opentelemetry.io/collector/receiver v1.35.0 // indirect
-	go.opentelemetry.io/collector/receiver/xreceiver v0.128.1 // indirect
-	go.opentelemetry.io/collector/service/hostcapabilities v0.128.1 // indirect
+	go.opentelemetry.io/collector/receiver/xreceiver v0.129.0 // indirect
+	go.opentelemetry.io/collector/service/hostcapabilities v0.129.0 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.11.0 // indirect
 	go.opentelemetry.io/contrib/otelconf v0.16.0 // indirect
 	go.opentelemetry.io/contrib/propagators/b3 v1.36.0 // indirect

--- a/pdata/pprofile/go.mod
+++ b/pdata/pprofile/go.mod
@@ -5,7 +5,7 @@ go 1.23.0
 require (
 	github.com/json-iterator/go v1.1.12
 	github.com/stretchr/testify v1.10.0
-	go.opentelemetry.io/collector/pdata v1.34.1
+	go.opentelemetry.io/collector/pdata v1.35.0
 	go.uber.org/goleak v1.3.0
 	google.golang.org/grpc v1.73.0
 )

--- a/pdata/testdata/go.mod
+++ b/pdata/testdata/go.mod
@@ -4,7 +4,7 @@ go 1.23.0
 
 require (
 	go.opentelemetry.io/collector/pdata v1.35.0
-	go.opentelemetry.io/collector/pdata/pprofile v0.128.1
+	go.opentelemetry.io/collector/pdata/pprofile v0.129.0
 )
 
 require (

--- a/pdata/testdata/go.mod
+++ b/pdata/testdata/go.mod
@@ -3,7 +3,7 @@ module go.opentelemetry.io/collector/pdata/testdata
 go 1.23.0
 
 require (
-	go.opentelemetry.io/collector/pdata v1.34.1
+	go.opentelemetry.io/collector/pdata v1.35.0
 	go.opentelemetry.io/collector/pdata/pprofile v0.128.1
 )
 

--- a/pdata/xpdata/go.mod
+++ b/pdata/xpdata/go.mod
@@ -7,8 +7,8 @@ require (
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/client v1.35.0
 	go.opentelemetry.io/collector/pdata v1.35.0
-	go.opentelemetry.io/collector/pdata/pprofile v0.128.1
-	go.opentelemetry.io/collector/pdata/testdata v0.128.1
+	go.opentelemetry.io/collector/pdata/pprofile v0.129.0
+	go.opentelemetry.io/collector/pdata/testdata v0.129.0
 	go.opentelemetry.io/otel/trace v1.36.0
 )
 

--- a/pdata/xpdata/go.mod
+++ b/pdata/xpdata/go.mod
@@ -5,8 +5,8 @@ go 1.23.0
 require (
 	github.com/gogo/protobuf v1.3.2
 	github.com/stretchr/testify v1.10.0
-	go.opentelemetry.io/collector/client v1.34.1
-	go.opentelemetry.io/collector/pdata v1.34.1
+	go.opentelemetry.io/collector/client v1.35.0
+	go.opentelemetry.io/collector/pdata v1.35.0
 	go.opentelemetry.io/collector/pdata/pprofile v0.128.1
 	go.opentelemetry.io/collector/pdata/testdata v0.128.1
 	go.opentelemetry.io/otel/trace v1.36.0

--- a/pipeline/xpipeline/go.mod
+++ b/pipeline/xpipeline/go.mod
@@ -2,6 +2,6 @@ module go.opentelemetry.io/collector/pipeline/xpipeline
 
 go 1.23.0
 
-require go.opentelemetry.io/collector/pipeline v0.128.1
+require go.opentelemetry.io/collector/pipeline v0.129.0
 
 replace go.opentelemetry.io/collector/pipeline => ../

--- a/processor/batchprocessor/go.mod
+++ b/processor/batchprocessor/go.mod
@@ -4,16 +4,16 @@ go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0
-	go.opentelemetry.io/collector/client v1.34.1
-	go.opentelemetry.io/collector/component v1.34.1
+	go.opentelemetry.io/collector/client v1.35.0
+	go.opentelemetry.io/collector/component v1.35.0
 	go.opentelemetry.io/collector/component/componenttest v0.128.1
-	go.opentelemetry.io/collector/confmap v1.34.1
-	go.opentelemetry.io/collector/consumer v1.34.1
+	go.opentelemetry.io/collector/confmap v1.35.0
+	go.opentelemetry.io/collector/consumer v1.35.0
 	go.opentelemetry.io/collector/consumer/consumererror v0.128.1
 	go.opentelemetry.io/collector/consumer/consumertest v0.128.1
-	go.opentelemetry.io/collector/pdata v1.34.1
+	go.opentelemetry.io/collector/pdata v1.35.0
 	go.opentelemetry.io/collector/pdata/testdata v0.128.1
-	go.opentelemetry.io/collector/processor v1.34.1
+	go.opentelemetry.io/collector/processor v1.35.0
 	go.opentelemetry.io/collector/processor/processortest v0.128.1
 	go.opentelemetry.io/otel v1.36.0
 	go.opentelemetry.io/otel/metric v1.36.0
@@ -44,7 +44,7 @@ require (
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/collector/component/componentstatus v0.128.1 // indirect
 	go.opentelemetry.io/collector/consumer/xconsumer v0.128.1 // indirect
-	go.opentelemetry.io/collector/featuregate v1.34.1 // indirect
+	go.opentelemetry.io/collector/featuregate v1.35.0 // indirect
 	go.opentelemetry.io/collector/internal/telemetry v0.128.1 // indirect
 	go.opentelemetry.io/collector/pdata/pprofile v0.128.1 // indirect
 	go.opentelemetry.io/collector/pipeline v0.128.1 // indirect

--- a/processor/batchprocessor/go.mod
+++ b/processor/batchprocessor/go.mod
@@ -6,15 +6,15 @@ require (
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/client v1.35.0
 	go.opentelemetry.io/collector/component v1.35.0
-	go.opentelemetry.io/collector/component/componenttest v0.128.1
+	go.opentelemetry.io/collector/component/componenttest v0.129.0
 	go.opentelemetry.io/collector/confmap v1.35.0
 	go.opentelemetry.io/collector/consumer v1.35.0
-	go.opentelemetry.io/collector/consumer/consumererror v0.128.1
-	go.opentelemetry.io/collector/consumer/consumertest v0.128.1
+	go.opentelemetry.io/collector/consumer/consumererror v0.129.0
+	go.opentelemetry.io/collector/consumer/consumertest v0.129.0
 	go.opentelemetry.io/collector/pdata v1.35.0
-	go.opentelemetry.io/collector/pdata/testdata v0.128.1
+	go.opentelemetry.io/collector/pdata/testdata v0.129.0
 	go.opentelemetry.io/collector/processor v1.35.0
-	go.opentelemetry.io/collector/processor/processortest v0.128.1
+	go.opentelemetry.io/collector/processor/processortest v0.129.0
 	go.opentelemetry.io/otel v1.36.0
 	go.opentelemetry.io/otel/metric v1.36.0
 	go.opentelemetry.io/otel/sdk/metric v1.36.0
@@ -42,13 +42,13 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
-	go.opentelemetry.io/collector/component/componentstatus v0.128.1 // indirect
-	go.opentelemetry.io/collector/consumer/xconsumer v0.128.1 // indirect
+	go.opentelemetry.io/collector/component/componentstatus v0.129.0 // indirect
+	go.opentelemetry.io/collector/consumer/xconsumer v0.129.0 // indirect
 	go.opentelemetry.io/collector/featuregate v1.35.0 // indirect
-	go.opentelemetry.io/collector/internal/telemetry v0.128.1 // indirect
-	go.opentelemetry.io/collector/pdata/pprofile v0.128.1 // indirect
-	go.opentelemetry.io/collector/pipeline v0.128.1 // indirect
-	go.opentelemetry.io/collector/processor/xprocessor v0.128.1 // indirect
+	go.opentelemetry.io/collector/internal/telemetry v0.129.0 // indirect
+	go.opentelemetry.io/collector/pdata/pprofile v0.129.0 // indirect
+	go.opentelemetry.io/collector/pipeline v0.129.0 // indirect
+	go.opentelemetry.io/collector/processor/xprocessor v0.129.0 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.11.0 // indirect
 	go.opentelemetry.io/otel/log v0.12.2 // indirect
 	go.opentelemetry.io/otel/sdk v1.36.0 // indirect

--- a/processor/go.mod
+++ b/processor/go.mod
@@ -4,8 +4,8 @@ go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0
-	go.opentelemetry.io/collector/component v1.34.1
-	go.opentelemetry.io/collector/consumer v1.34.1
+	go.opentelemetry.io/collector/component v1.35.0
+	go.opentelemetry.io/collector/consumer v1.35.0
 	go.opentelemetry.io/collector/consumer/consumertest v0.128.1
 	go.opentelemetry.io/collector/pipeline v0.128.1
 	go.uber.org/goleak v1.3.0
@@ -24,9 +24,9 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/collector/consumer/xconsumer v0.128.1 // indirect
-	go.opentelemetry.io/collector/featuregate v1.34.1 // indirect
+	go.opentelemetry.io/collector/featuregate v1.35.0 // indirect
 	go.opentelemetry.io/collector/internal/telemetry v0.128.1 // indirect
-	go.opentelemetry.io/collector/pdata v1.34.1 // indirect
+	go.opentelemetry.io/collector/pdata v1.35.0 // indirect
 	go.opentelemetry.io/collector/pdata/pprofile v0.128.1 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.11.0 // indirect
 	go.opentelemetry.io/otel v1.36.0 // indirect

--- a/processor/go.mod
+++ b/processor/go.mod
@@ -6,8 +6,8 @@ require (
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/component v1.35.0
 	go.opentelemetry.io/collector/consumer v1.35.0
-	go.opentelemetry.io/collector/consumer/consumertest v0.128.1
-	go.opentelemetry.io/collector/pipeline v0.128.1
+	go.opentelemetry.io/collector/consumer/consumertest v0.129.0
+	go.opentelemetry.io/collector/pipeline v0.129.0
 	go.uber.org/goleak v1.3.0
 )
 
@@ -23,11 +23,11 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
-	go.opentelemetry.io/collector/consumer/xconsumer v0.128.1 // indirect
+	go.opentelemetry.io/collector/consumer/xconsumer v0.129.0 // indirect
 	go.opentelemetry.io/collector/featuregate v1.35.0 // indirect
-	go.opentelemetry.io/collector/internal/telemetry v0.128.1 // indirect
+	go.opentelemetry.io/collector/internal/telemetry v0.129.0 // indirect
 	go.opentelemetry.io/collector/pdata v1.35.0 // indirect
-	go.opentelemetry.io/collector/pdata/pprofile v0.128.1 // indirect
+	go.opentelemetry.io/collector/pdata/pprofile v0.129.0 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.11.0 // indirect
 	go.opentelemetry.io/otel v1.36.0 // indirect
 	go.opentelemetry.io/otel/log v0.12.2 // indirect

--- a/processor/memorylimiterprocessor/go.mod
+++ b/processor/memorylimiterprocessor/go.mod
@@ -5,23 +5,23 @@ go 1.23.0
 require (
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/component v1.35.0
-	go.opentelemetry.io/collector/component/componenttest v0.128.1
+	go.opentelemetry.io/collector/component/componenttest v0.129.0
 	go.opentelemetry.io/collector/confmap v1.35.0
 	go.opentelemetry.io/collector/consumer v1.35.0
-	go.opentelemetry.io/collector/consumer/consumererror v0.128.1
-	go.opentelemetry.io/collector/consumer/consumertest v0.128.1
-	go.opentelemetry.io/collector/consumer/xconsumer v0.128.1
-	go.opentelemetry.io/collector/internal/memorylimiter v0.128.1
-	go.opentelemetry.io/collector/internal/telemetry v0.128.1
+	go.opentelemetry.io/collector/consumer/consumererror v0.129.0
+	go.opentelemetry.io/collector/consumer/consumertest v0.129.0
+	go.opentelemetry.io/collector/consumer/xconsumer v0.129.0
+	go.opentelemetry.io/collector/internal/memorylimiter v0.129.0
+	go.opentelemetry.io/collector/internal/telemetry v0.129.0
 	go.opentelemetry.io/collector/pdata v1.35.0
-	go.opentelemetry.io/collector/pdata/pprofile v0.128.1
-	go.opentelemetry.io/collector/pipeline v0.128.1
-	go.opentelemetry.io/collector/pipeline/xpipeline v0.128.1
+	go.opentelemetry.io/collector/pdata/pprofile v0.129.0
+	go.opentelemetry.io/collector/pipeline v0.129.0
+	go.opentelemetry.io/collector/pipeline/xpipeline v0.129.0
 	go.opentelemetry.io/collector/processor v1.35.0
-	go.opentelemetry.io/collector/processor/processorhelper v0.128.1
-	go.opentelemetry.io/collector/processor/processorhelper/xprocessorhelper v0.128.1
-	go.opentelemetry.io/collector/processor/processortest v0.128.1
-	go.opentelemetry.io/collector/processor/xprocessor v0.128.1
+	go.opentelemetry.io/collector/processor/processorhelper v0.129.0
+	go.opentelemetry.io/collector/processor/processorhelper/xprocessorhelper v0.129.0
+	go.opentelemetry.io/collector/processor/processortest v0.129.0
+	go.opentelemetry.io/collector/processor/xprocessor v0.129.0
 	go.opentelemetry.io/otel v1.36.0
 	go.opentelemetry.io/otel/metric v1.36.0
 	go.opentelemetry.io/otel/sdk/metric v1.36.0
@@ -57,9 +57,9 @@ require (
 	github.com/tklauser/numcpus v0.6.1 // indirect
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
-	go.opentelemetry.io/collector/component/componentstatus v0.128.1 // indirect
+	go.opentelemetry.io/collector/component/componentstatus v0.129.0 // indirect
 	go.opentelemetry.io/collector/featuregate v1.35.0 // indirect
-	go.opentelemetry.io/collector/pdata/testdata v0.128.1 // indirect
+	go.opentelemetry.io/collector/pdata/testdata v0.129.0 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.11.0 // indirect
 	go.opentelemetry.io/otel/log v0.12.2 // indirect
 	go.opentelemetry.io/otel/sdk v1.36.0 // indirect

--- a/processor/memorylimiterprocessor/go.mod
+++ b/processor/memorylimiterprocessor/go.mod
@@ -4,20 +4,20 @@ go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0
-	go.opentelemetry.io/collector/component v1.34.1
+	go.opentelemetry.io/collector/component v1.35.0
 	go.opentelemetry.io/collector/component/componenttest v0.128.1
-	go.opentelemetry.io/collector/confmap v1.34.1
-	go.opentelemetry.io/collector/consumer v1.34.1
+	go.opentelemetry.io/collector/confmap v1.35.0
+	go.opentelemetry.io/collector/consumer v1.35.0
 	go.opentelemetry.io/collector/consumer/consumererror v0.128.1
 	go.opentelemetry.io/collector/consumer/consumertest v0.128.1
 	go.opentelemetry.io/collector/consumer/xconsumer v0.128.1
 	go.opentelemetry.io/collector/internal/memorylimiter v0.128.1
 	go.opentelemetry.io/collector/internal/telemetry v0.128.1
-	go.opentelemetry.io/collector/pdata v1.34.1
+	go.opentelemetry.io/collector/pdata v1.35.0
 	go.opentelemetry.io/collector/pdata/pprofile v0.128.1
 	go.opentelemetry.io/collector/pipeline v0.128.1
 	go.opentelemetry.io/collector/pipeline/xpipeline v0.128.1
-	go.opentelemetry.io/collector/processor v1.34.1
+	go.opentelemetry.io/collector/processor v1.35.0
 	go.opentelemetry.io/collector/processor/processorhelper v0.128.1
 	go.opentelemetry.io/collector/processor/processorhelper/xprocessorhelper v0.128.1
 	go.opentelemetry.io/collector/processor/processortest v0.128.1
@@ -58,7 +58,7 @@ require (
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/collector/component/componentstatus v0.128.1 // indirect
-	go.opentelemetry.io/collector/featuregate v1.34.1 // indirect
+	go.opentelemetry.io/collector/featuregate v1.35.0 // indirect
 	go.opentelemetry.io/collector/pdata/testdata v0.128.1 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.11.0 // indirect
 	go.opentelemetry.io/otel/log v0.12.2 // indirect

--- a/processor/processorhelper/go.mod
+++ b/processor/processorhelper/go.mod
@@ -7,13 +7,13 @@ replace go.opentelemetry.io/collector/processor => ../
 require (
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/component v1.35.0
-	go.opentelemetry.io/collector/component/componenttest v0.128.1
+	go.opentelemetry.io/collector/component/componenttest v0.129.0
 	go.opentelemetry.io/collector/consumer v1.35.0
-	go.opentelemetry.io/collector/consumer/consumertest v0.128.1
+	go.opentelemetry.io/collector/consumer/consumertest v0.129.0
 	go.opentelemetry.io/collector/pdata v1.35.0
-	go.opentelemetry.io/collector/pipeline v0.128.1
+	go.opentelemetry.io/collector/pipeline v0.129.0
 	go.opentelemetry.io/collector/processor v1.35.0
-	go.opentelemetry.io/collector/processor/processortest v0.128.1
+	go.opentelemetry.io/collector/processor/processortest v0.129.0
 	go.opentelemetry.io/otel v1.36.0
 	go.opentelemetry.io/otel/metric v1.36.0
 	go.opentelemetry.io/otel/sdk/metric v1.36.0
@@ -33,13 +33,13 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
-	go.opentelemetry.io/collector/component/componentstatus v0.128.1 // indirect
-	go.opentelemetry.io/collector/consumer/xconsumer v0.128.1 // indirect
+	go.opentelemetry.io/collector/component/componentstatus v0.129.0 // indirect
+	go.opentelemetry.io/collector/consumer/xconsumer v0.129.0 // indirect
 	go.opentelemetry.io/collector/featuregate v1.35.0 // indirect
-	go.opentelemetry.io/collector/internal/telemetry v0.128.1 // indirect
-	go.opentelemetry.io/collector/pdata/pprofile v0.128.1 // indirect
-	go.opentelemetry.io/collector/pdata/testdata v0.128.1 // indirect
-	go.opentelemetry.io/collector/processor/xprocessor v0.128.1 // indirect
+	go.opentelemetry.io/collector/internal/telemetry v0.129.0 // indirect
+	go.opentelemetry.io/collector/pdata/pprofile v0.129.0 // indirect
+	go.opentelemetry.io/collector/pdata/testdata v0.129.0 // indirect
+	go.opentelemetry.io/collector/processor/xprocessor v0.129.0 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.11.0 // indirect
 	go.opentelemetry.io/otel/log v0.12.2 // indirect
 	go.opentelemetry.io/otel/sdk v1.36.0 // indirect

--- a/processor/processorhelper/go.mod
+++ b/processor/processorhelper/go.mod
@@ -6,13 +6,13 @@ replace go.opentelemetry.io/collector/processor => ../
 
 require (
 	github.com/stretchr/testify v1.10.0
-	go.opentelemetry.io/collector/component v1.34.1
+	go.opentelemetry.io/collector/component v1.35.0
 	go.opentelemetry.io/collector/component/componenttest v0.128.1
-	go.opentelemetry.io/collector/consumer v1.34.1
+	go.opentelemetry.io/collector/consumer v1.35.0
 	go.opentelemetry.io/collector/consumer/consumertest v0.128.1
-	go.opentelemetry.io/collector/pdata v1.34.1
+	go.opentelemetry.io/collector/pdata v1.35.0
 	go.opentelemetry.io/collector/pipeline v0.128.1
-	go.opentelemetry.io/collector/processor v1.34.1
+	go.opentelemetry.io/collector/processor v1.35.0
 	go.opentelemetry.io/collector/processor/processortest v0.128.1
 	go.opentelemetry.io/otel v1.36.0
 	go.opentelemetry.io/otel/metric v1.36.0
@@ -35,7 +35,7 @@ require (
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/collector/component/componentstatus v0.128.1 // indirect
 	go.opentelemetry.io/collector/consumer/xconsumer v0.128.1 // indirect
-	go.opentelemetry.io/collector/featuregate v1.34.1 // indirect
+	go.opentelemetry.io/collector/featuregate v1.35.0 // indirect
 	go.opentelemetry.io/collector/internal/telemetry v0.128.1 // indirect
 	go.opentelemetry.io/collector/pdata/pprofile v0.128.1 // indirect
 	go.opentelemetry.io/collector/pdata/testdata v0.128.1 // indirect

--- a/processor/processorhelper/xprocessorhelper/go.mod
+++ b/processor/processorhelper/xprocessorhelper/go.mod
@@ -5,15 +5,15 @@ go 1.23.0
 require (
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/component v1.35.0
-	go.opentelemetry.io/collector/component/componenttest v0.128.1
+	go.opentelemetry.io/collector/component/componenttest v0.129.0
 	go.opentelemetry.io/collector/consumer v1.35.0
-	go.opentelemetry.io/collector/consumer/consumertest v0.128.1
-	go.opentelemetry.io/collector/consumer/xconsumer v0.128.1
-	go.opentelemetry.io/collector/pdata/pprofile v0.128.1
+	go.opentelemetry.io/collector/consumer/consumertest v0.129.0
+	go.opentelemetry.io/collector/consumer/xconsumer v0.129.0
+	go.opentelemetry.io/collector/pdata/pprofile v0.129.0
 	go.opentelemetry.io/collector/processor v1.35.0
-	go.opentelemetry.io/collector/processor/processorhelper v0.128.1
-	go.opentelemetry.io/collector/processor/processortest v0.128.1
-	go.opentelemetry.io/collector/processor/xprocessor v0.128.1
+	go.opentelemetry.io/collector/processor/processorhelper v0.129.0
+	go.opentelemetry.io/collector/processor/processortest v0.129.0
+	go.opentelemetry.io/collector/processor/xprocessor v0.129.0
 )
 
 require (
@@ -28,12 +28,12 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
-	go.opentelemetry.io/collector/component/componentstatus v0.128.1 // indirect
+	go.opentelemetry.io/collector/component/componentstatus v0.129.0 // indirect
 	go.opentelemetry.io/collector/featuregate v1.35.0 // indirect
-	go.opentelemetry.io/collector/internal/telemetry v0.128.1 // indirect
+	go.opentelemetry.io/collector/internal/telemetry v0.129.0 // indirect
 	go.opentelemetry.io/collector/pdata v1.35.0 // indirect
-	go.opentelemetry.io/collector/pdata/testdata v0.128.1 // indirect
-	go.opentelemetry.io/collector/pipeline v0.128.1 // indirect
+	go.opentelemetry.io/collector/pdata/testdata v0.129.0 // indirect
+	go.opentelemetry.io/collector/pipeline v0.129.0 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.11.0 // indirect
 	go.opentelemetry.io/otel v1.36.0 // indirect
 	go.opentelemetry.io/otel/log v0.12.2 // indirect

--- a/processor/processorhelper/xprocessorhelper/go.mod
+++ b/processor/processorhelper/xprocessorhelper/go.mod
@@ -4,13 +4,13 @@ go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0
-	go.opentelemetry.io/collector/component v1.34.1
+	go.opentelemetry.io/collector/component v1.35.0
 	go.opentelemetry.io/collector/component/componenttest v0.128.1
-	go.opentelemetry.io/collector/consumer v1.34.1
+	go.opentelemetry.io/collector/consumer v1.35.0
 	go.opentelemetry.io/collector/consumer/consumertest v0.128.1
 	go.opentelemetry.io/collector/consumer/xconsumer v0.128.1
 	go.opentelemetry.io/collector/pdata/pprofile v0.128.1
-	go.opentelemetry.io/collector/processor v1.34.1
+	go.opentelemetry.io/collector/processor v1.35.0
 	go.opentelemetry.io/collector/processor/processorhelper v0.128.1
 	go.opentelemetry.io/collector/processor/processortest v0.128.1
 	go.opentelemetry.io/collector/processor/xprocessor v0.128.1
@@ -29,9 +29,9 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/collector/component/componentstatus v0.128.1 // indirect
-	go.opentelemetry.io/collector/featuregate v1.34.1 // indirect
+	go.opentelemetry.io/collector/featuregate v1.35.0 // indirect
 	go.opentelemetry.io/collector/internal/telemetry v0.128.1 // indirect
-	go.opentelemetry.io/collector/pdata v1.34.1 // indirect
+	go.opentelemetry.io/collector/pdata v1.35.0 // indirect
 	go.opentelemetry.io/collector/pdata/testdata v0.128.1 // indirect
 	go.opentelemetry.io/collector/pipeline v0.128.1 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.11.0 // indirect

--- a/processor/processortest/go.mod
+++ b/processor/processortest/go.mod
@@ -4,17 +4,17 @@ go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0
-	go.opentelemetry.io/collector/component v1.34.1
+	go.opentelemetry.io/collector/component v1.35.0
 	go.opentelemetry.io/collector/component/componentstatus v0.128.1
 	go.opentelemetry.io/collector/component/componenttest v0.128.1
-	go.opentelemetry.io/collector/consumer v1.34.1
+	go.opentelemetry.io/collector/consumer v1.35.0
 	go.opentelemetry.io/collector/consumer/consumertest v0.128.1
 	go.opentelemetry.io/collector/consumer/xconsumer v0.128.1
-	go.opentelemetry.io/collector/pdata v1.34.1
+	go.opentelemetry.io/collector/pdata v1.35.0
 	go.opentelemetry.io/collector/pdata/pprofile v0.128.1
 	go.opentelemetry.io/collector/pdata/testdata v0.128.1
 	go.opentelemetry.io/collector/pipeline v0.128.1
-	go.opentelemetry.io/collector/processor v1.34.1
+	go.opentelemetry.io/collector/processor v1.35.0
 	go.opentelemetry.io/collector/processor/xprocessor v0.128.1
 	go.uber.org/goleak v1.3.0
 )
@@ -31,7 +31,7 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
-	go.opentelemetry.io/collector/featuregate v1.34.1 // indirect
+	go.opentelemetry.io/collector/featuregate v1.35.0 // indirect
 	go.opentelemetry.io/collector/internal/telemetry v0.128.1 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.11.0 // indirect
 	go.opentelemetry.io/otel v1.36.0 // indirect

--- a/processor/processortest/go.mod
+++ b/processor/processortest/go.mod
@@ -5,17 +5,17 @@ go 1.23.0
 require (
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/component v1.35.0
-	go.opentelemetry.io/collector/component/componentstatus v0.128.1
-	go.opentelemetry.io/collector/component/componenttest v0.128.1
+	go.opentelemetry.io/collector/component/componentstatus v0.129.0
+	go.opentelemetry.io/collector/component/componenttest v0.129.0
 	go.opentelemetry.io/collector/consumer v1.35.0
-	go.opentelemetry.io/collector/consumer/consumertest v0.128.1
-	go.opentelemetry.io/collector/consumer/xconsumer v0.128.1
+	go.opentelemetry.io/collector/consumer/consumertest v0.129.0
+	go.opentelemetry.io/collector/consumer/xconsumer v0.129.0
 	go.opentelemetry.io/collector/pdata v1.35.0
-	go.opentelemetry.io/collector/pdata/pprofile v0.128.1
-	go.opentelemetry.io/collector/pdata/testdata v0.128.1
-	go.opentelemetry.io/collector/pipeline v0.128.1
+	go.opentelemetry.io/collector/pdata/pprofile v0.129.0
+	go.opentelemetry.io/collector/pdata/testdata v0.129.0
+	go.opentelemetry.io/collector/pipeline v0.129.0
 	go.opentelemetry.io/collector/processor v1.35.0
-	go.opentelemetry.io/collector/processor/xprocessor v0.128.1
+	go.opentelemetry.io/collector/processor/xprocessor v0.129.0
 	go.uber.org/goleak v1.3.0
 )
 
@@ -32,7 +32,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/collector/featuregate v1.35.0 // indirect
-	go.opentelemetry.io/collector/internal/telemetry v0.128.1 // indirect
+	go.opentelemetry.io/collector/internal/telemetry v0.129.0 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.11.0 // indirect
 	go.opentelemetry.io/otel v1.36.0 // indirect
 	go.opentelemetry.io/otel/log v0.12.2 // indirect

--- a/processor/xprocessor/go.mod
+++ b/processor/xprocessor/go.mod
@@ -4,11 +4,11 @@ go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0
-	go.opentelemetry.io/collector/component v1.34.1
+	go.opentelemetry.io/collector/component v1.35.0
 	go.opentelemetry.io/collector/consumer/consumertest v0.128.1
 	go.opentelemetry.io/collector/consumer/xconsumer v0.128.1
 	go.opentelemetry.io/collector/pipeline v0.128.1
-	go.opentelemetry.io/collector/processor v1.34.1
+	go.opentelemetry.io/collector/processor v1.35.0
 )
 
 require (
@@ -23,10 +23,10 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
-	go.opentelemetry.io/collector/consumer v1.34.1 // indirect
-	go.opentelemetry.io/collector/featuregate v1.34.1 // indirect
+	go.opentelemetry.io/collector/consumer v1.35.0 // indirect
+	go.opentelemetry.io/collector/featuregate v1.35.0 // indirect
 	go.opentelemetry.io/collector/internal/telemetry v0.128.1 // indirect
-	go.opentelemetry.io/collector/pdata v1.34.1 // indirect
+	go.opentelemetry.io/collector/pdata v1.35.0 // indirect
 	go.opentelemetry.io/collector/pdata/pprofile v0.128.1 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.11.0 // indirect
 	go.opentelemetry.io/otel v1.36.0 // indirect

--- a/processor/xprocessor/go.mod
+++ b/processor/xprocessor/go.mod
@@ -5,9 +5,9 @@ go 1.23.0
 require (
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/component v1.35.0
-	go.opentelemetry.io/collector/consumer/consumertest v0.128.1
-	go.opentelemetry.io/collector/consumer/xconsumer v0.128.1
-	go.opentelemetry.io/collector/pipeline v0.128.1
+	go.opentelemetry.io/collector/consumer/consumertest v0.129.0
+	go.opentelemetry.io/collector/consumer/xconsumer v0.129.0
+	go.opentelemetry.io/collector/pipeline v0.129.0
 	go.opentelemetry.io/collector/processor v1.35.0
 )
 
@@ -25,9 +25,9 @@ require (
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/collector/consumer v1.35.0 // indirect
 	go.opentelemetry.io/collector/featuregate v1.35.0 // indirect
-	go.opentelemetry.io/collector/internal/telemetry v0.128.1 // indirect
+	go.opentelemetry.io/collector/internal/telemetry v0.129.0 // indirect
 	go.opentelemetry.io/collector/pdata v1.35.0 // indirect
-	go.opentelemetry.io/collector/pdata/pprofile v0.128.1 // indirect
+	go.opentelemetry.io/collector/pdata/pprofile v0.129.0 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.11.0 // indirect
 	go.opentelemetry.io/otel v1.36.0 // indirect
 	go.opentelemetry.io/otel/log v0.12.2 // indirect

--- a/receiver/go.mod
+++ b/receiver/go.mod
@@ -4,10 +4,10 @@ go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0
-	go.opentelemetry.io/collector/component v1.34.1
-	go.opentelemetry.io/collector/consumer v1.34.1
+	go.opentelemetry.io/collector/component v1.35.0
+	go.opentelemetry.io/collector/consumer v1.35.0
 	go.opentelemetry.io/collector/consumer/consumertest v0.128.1
-	go.opentelemetry.io/collector/pdata v1.34.1
+	go.opentelemetry.io/collector/pdata v1.35.0
 	go.opentelemetry.io/collector/pipeline v0.128.1
 	go.uber.org/goleak v1.3.0
 )
@@ -25,7 +25,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/collector/consumer/xconsumer v0.128.1 // indirect
-	go.opentelemetry.io/collector/featuregate v1.34.1 // indirect
+	go.opentelemetry.io/collector/featuregate v1.35.0 // indirect
 	go.opentelemetry.io/collector/internal/telemetry v0.128.1 // indirect
 	go.opentelemetry.io/collector/pdata/pprofile v0.128.1 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.11.0 // indirect

--- a/receiver/go.mod
+++ b/receiver/go.mod
@@ -6,9 +6,9 @@ require (
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/component v1.35.0
 	go.opentelemetry.io/collector/consumer v1.35.0
-	go.opentelemetry.io/collector/consumer/consumertest v0.128.1
+	go.opentelemetry.io/collector/consumer/consumertest v0.129.0
 	go.opentelemetry.io/collector/pdata v1.35.0
-	go.opentelemetry.io/collector/pipeline v0.128.1
+	go.opentelemetry.io/collector/pipeline v0.129.0
 	go.uber.org/goleak v1.3.0
 )
 
@@ -24,10 +24,10 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
-	go.opentelemetry.io/collector/consumer/xconsumer v0.128.1 // indirect
+	go.opentelemetry.io/collector/consumer/xconsumer v0.129.0 // indirect
 	go.opentelemetry.io/collector/featuregate v1.35.0 // indirect
-	go.opentelemetry.io/collector/internal/telemetry v0.128.1 // indirect
-	go.opentelemetry.io/collector/pdata/pprofile v0.128.1 // indirect
+	go.opentelemetry.io/collector/internal/telemetry v0.129.0 // indirect
+	go.opentelemetry.io/collector/pdata/pprofile v0.129.0 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.11.0 // indirect
 	go.opentelemetry.io/otel v1.36.0 // indirect
 	go.opentelemetry.io/otel/log v0.12.2 // indirect

--- a/receiver/nopreceiver/go.mod
+++ b/receiver/nopreceiver/go.mod
@@ -4,13 +4,13 @@ go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0
-	go.opentelemetry.io/collector/component v1.34.1
+	go.opentelemetry.io/collector/component v1.35.0
 	go.opentelemetry.io/collector/component/componenttest v0.128.1
-	go.opentelemetry.io/collector/confmap v1.34.1
-	go.opentelemetry.io/collector/consumer v1.34.1
+	go.opentelemetry.io/collector/confmap v1.35.0
+	go.opentelemetry.io/collector/consumer v1.35.0
 	go.opentelemetry.io/collector/consumer/consumertest v0.128.1
-	go.opentelemetry.io/collector/pdata v1.34.1
-	go.opentelemetry.io/collector/receiver v1.34.1
+	go.opentelemetry.io/collector/pdata v1.35.0
+	go.opentelemetry.io/collector/receiver v1.35.0
 	go.opentelemetry.io/collector/receiver/receivertest v0.128.1
 	go.uber.org/goleak v1.3.0
 	go.uber.org/zap v1.27.0
@@ -37,7 +37,7 @@ require (
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/collector/consumer/consumererror v0.128.1 // indirect
 	go.opentelemetry.io/collector/consumer/xconsumer v0.128.1 // indirect
-	go.opentelemetry.io/collector/featuregate v1.34.1 // indirect
+	go.opentelemetry.io/collector/featuregate v1.35.0 // indirect
 	go.opentelemetry.io/collector/internal/telemetry v0.128.1 // indirect
 	go.opentelemetry.io/collector/pdata/pprofile v0.128.1 // indirect
 	go.opentelemetry.io/collector/pipeline v0.128.1 // indirect

--- a/receiver/nopreceiver/go.mod
+++ b/receiver/nopreceiver/go.mod
@@ -5,13 +5,13 @@ go 1.23.0
 require (
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/component v1.35.0
-	go.opentelemetry.io/collector/component/componenttest v0.128.1
+	go.opentelemetry.io/collector/component/componenttest v0.129.0
 	go.opentelemetry.io/collector/confmap v1.35.0
 	go.opentelemetry.io/collector/consumer v1.35.0
-	go.opentelemetry.io/collector/consumer/consumertest v0.128.1
+	go.opentelemetry.io/collector/consumer/consumertest v0.129.0
 	go.opentelemetry.io/collector/pdata v1.35.0
 	go.opentelemetry.io/collector/receiver v1.35.0
-	go.opentelemetry.io/collector/receiver/receivertest v0.128.1
+	go.opentelemetry.io/collector/receiver/receivertest v0.129.0
 	go.uber.org/goleak v1.3.0
 	go.uber.org/zap v1.27.0
 )
@@ -35,13 +35,13 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
-	go.opentelemetry.io/collector/consumer/consumererror v0.128.1 // indirect
-	go.opentelemetry.io/collector/consumer/xconsumer v0.128.1 // indirect
+	go.opentelemetry.io/collector/consumer/consumererror v0.129.0 // indirect
+	go.opentelemetry.io/collector/consumer/xconsumer v0.129.0 // indirect
 	go.opentelemetry.io/collector/featuregate v1.35.0 // indirect
-	go.opentelemetry.io/collector/internal/telemetry v0.128.1 // indirect
-	go.opentelemetry.io/collector/pdata/pprofile v0.128.1 // indirect
-	go.opentelemetry.io/collector/pipeline v0.128.1 // indirect
-	go.opentelemetry.io/collector/receiver/xreceiver v0.128.1 // indirect
+	go.opentelemetry.io/collector/internal/telemetry v0.129.0 // indirect
+	go.opentelemetry.io/collector/pdata/pprofile v0.129.0 // indirect
+	go.opentelemetry.io/collector/pipeline v0.129.0 // indirect
+	go.opentelemetry.io/collector/receiver/xreceiver v0.129.0 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.11.0 // indirect
 	go.opentelemetry.io/otel v1.36.0 // indirect
 	go.opentelemetry.io/otel/log v0.12.2 // indirect

--- a/receiver/otlpreceiver/go.mod
+++ b/receiver/otlpreceiver/go.mod
@@ -7,28 +7,28 @@ require (
 	github.com/klauspost/compress v1.18.0
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector v0.128.1
-	go.opentelemetry.io/collector/component v1.34.1
+	go.opentelemetry.io/collector/component v1.35.0
 	go.opentelemetry.io/collector/component/componentstatus v0.128.1
 	go.opentelemetry.io/collector/component/componenttest v0.128.1
 	go.opentelemetry.io/collector/config/configauth v0.128.1
 	go.opentelemetry.io/collector/config/configgrpc v0.128.1
 	go.opentelemetry.io/collector/config/confighttp v0.128.1
-	go.opentelemetry.io/collector/config/confignet v1.34.1
-	go.opentelemetry.io/collector/config/configopaque v1.34.1
+	go.opentelemetry.io/collector/config/confignet v1.35.0
+	go.opentelemetry.io/collector/config/configopaque v1.35.0
 	go.opentelemetry.io/collector/config/configoptional v0.128.1
-	go.opentelemetry.io/collector/config/configtls v1.34.1
-	go.opentelemetry.io/collector/confmap v1.34.1
+	go.opentelemetry.io/collector/config/configtls v1.35.0
+	go.opentelemetry.io/collector/confmap v1.35.0
 	go.opentelemetry.io/collector/confmap/xconfmap v0.128.1
-	go.opentelemetry.io/collector/consumer v1.34.1
+	go.opentelemetry.io/collector/consumer v1.35.0
 	go.opentelemetry.io/collector/consumer/consumererror v0.128.1
 	go.opentelemetry.io/collector/consumer/consumertest v0.128.1
 	go.opentelemetry.io/collector/consumer/xconsumer v0.128.1
 	go.opentelemetry.io/collector/internal/sharedcomponent v0.128.1
 	go.opentelemetry.io/collector/internal/telemetry v0.128.1
-	go.opentelemetry.io/collector/pdata v1.34.1
+	go.opentelemetry.io/collector/pdata v1.35.0
 	go.opentelemetry.io/collector/pdata/pprofile v0.128.1
 	go.opentelemetry.io/collector/pdata/testdata v0.128.1
-	go.opentelemetry.io/collector/receiver v1.34.1
+	go.opentelemetry.io/collector/receiver v1.35.0
 	go.opentelemetry.io/collector/receiver/receiverhelper v0.128.1
 	go.opentelemetry.io/collector/receiver/receivertest v0.128.1
 	go.opentelemetry.io/collector/receiver/xreceiver v0.128.1
@@ -67,12 +67,12 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rs/cors v1.11.1 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
-	go.opentelemetry.io/collector/client v1.34.1 // indirect
-	go.opentelemetry.io/collector/config/configcompression v1.34.1 // indirect
+	go.opentelemetry.io/collector/client v1.35.0 // indirect
+	go.opentelemetry.io/collector/config/configcompression v1.35.0 // indirect
 	go.opentelemetry.io/collector/config/configmiddleware v0.128.1 // indirect
-	go.opentelemetry.io/collector/extension/extensionauth v1.34.1 // indirect
+	go.opentelemetry.io/collector/extension/extensionauth v1.35.0 // indirect
 	go.opentelemetry.io/collector/extension/extensionmiddleware v0.128.1 // indirect
-	go.opentelemetry.io/collector/featuregate v1.34.1 // indirect
+	go.opentelemetry.io/collector/featuregate v1.35.0 // indirect
 	go.opentelemetry.io/collector/pipeline v0.128.1 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.11.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.61.0 // indirect

--- a/receiver/otlpreceiver/go.mod
+++ b/receiver/otlpreceiver/go.mod
@@ -6,32 +6,32 @@ require (
 	github.com/gogo/protobuf v1.3.2
 	github.com/klauspost/compress v1.18.0
 	github.com/stretchr/testify v1.10.0
-	go.opentelemetry.io/collector v0.128.1
+	go.opentelemetry.io/collector v0.129.0
 	go.opentelemetry.io/collector/component v1.35.0
-	go.opentelemetry.io/collector/component/componentstatus v0.128.1
-	go.opentelemetry.io/collector/component/componenttest v0.128.1
-	go.opentelemetry.io/collector/config/configauth v0.128.1
-	go.opentelemetry.io/collector/config/configgrpc v0.128.1
-	go.opentelemetry.io/collector/config/confighttp v0.128.1
+	go.opentelemetry.io/collector/component/componentstatus v0.129.0
+	go.opentelemetry.io/collector/component/componenttest v0.129.0
+	go.opentelemetry.io/collector/config/configauth v0.129.0
+	go.opentelemetry.io/collector/config/configgrpc v0.129.0
+	go.opentelemetry.io/collector/config/confighttp v0.129.0
 	go.opentelemetry.io/collector/config/confignet v1.35.0
 	go.opentelemetry.io/collector/config/configopaque v1.35.0
-	go.opentelemetry.io/collector/config/configoptional v0.128.1
+	go.opentelemetry.io/collector/config/configoptional v0.129.0
 	go.opentelemetry.io/collector/config/configtls v1.35.0
 	go.opentelemetry.io/collector/confmap v1.35.0
-	go.opentelemetry.io/collector/confmap/xconfmap v0.128.1
+	go.opentelemetry.io/collector/confmap/xconfmap v0.129.0
 	go.opentelemetry.io/collector/consumer v1.35.0
-	go.opentelemetry.io/collector/consumer/consumererror v0.128.1
-	go.opentelemetry.io/collector/consumer/consumertest v0.128.1
-	go.opentelemetry.io/collector/consumer/xconsumer v0.128.1
-	go.opentelemetry.io/collector/internal/sharedcomponent v0.128.1
-	go.opentelemetry.io/collector/internal/telemetry v0.128.1
+	go.opentelemetry.io/collector/consumer/consumererror v0.129.0
+	go.opentelemetry.io/collector/consumer/consumertest v0.129.0
+	go.opentelemetry.io/collector/consumer/xconsumer v0.129.0
+	go.opentelemetry.io/collector/internal/sharedcomponent v0.129.0
+	go.opentelemetry.io/collector/internal/telemetry v0.129.0
 	go.opentelemetry.io/collector/pdata v1.35.0
-	go.opentelemetry.io/collector/pdata/pprofile v0.128.1
-	go.opentelemetry.io/collector/pdata/testdata v0.128.1
+	go.opentelemetry.io/collector/pdata/pprofile v0.129.0
+	go.opentelemetry.io/collector/pdata/testdata v0.129.0
 	go.opentelemetry.io/collector/receiver v1.35.0
-	go.opentelemetry.io/collector/receiver/receiverhelper v0.128.1
-	go.opentelemetry.io/collector/receiver/receivertest v0.128.1
-	go.opentelemetry.io/collector/receiver/xreceiver v0.128.1
+	go.opentelemetry.io/collector/receiver/receiverhelper v0.129.0
+	go.opentelemetry.io/collector/receiver/receivertest v0.129.0
+	go.opentelemetry.io/collector/receiver/xreceiver v0.129.0
 	go.opentelemetry.io/otel v1.36.0
 	go.opentelemetry.io/otel/sdk/metric v1.36.0
 	go.uber.org/goleak v1.3.0
@@ -69,11 +69,11 @@ require (
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/collector/client v1.35.0 // indirect
 	go.opentelemetry.io/collector/config/configcompression v1.35.0 // indirect
-	go.opentelemetry.io/collector/config/configmiddleware v0.128.1 // indirect
+	go.opentelemetry.io/collector/config/configmiddleware v0.129.0 // indirect
 	go.opentelemetry.io/collector/extension/extensionauth v1.35.0 // indirect
-	go.opentelemetry.io/collector/extension/extensionmiddleware v0.128.1 // indirect
+	go.opentelemetry.io/collector/extension/extensionmiddleware v0.129.0 // indirect
 	go.opentelemetry.io/collector/featuregate v1.35.0 // indirect
-	go.opentelemetry.io/collector/pipeline v0.128.1 // indirect
+	go.opentelemetry.io/collector/pipeline v0.129.0 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.11.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.61.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.61.0 // indirect

--- a/receiver/receiverhelper/go.mod
+++ b/receiver/receiverhelper/go.mod
@@ -4,10 +4,10 @@ go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0
-	go.opentelemetry.io/collector/component v1.34.1
+	go.opentelemetry.io/collector/component v1.35.0
 	go.opentelemetry.io/collector/component/componenttest v0.128.1
 	go.opentelemetry.io/collector/pipeline v0.128.1
-	go.opentelemetry.io/collector/receiver v1.34.1
+	go.opentelemetry.io/collector/receiver v1.35.0
 	go.opentelemetry.io/otel v1.36.0
 	go.opentelemetry.io/otel/metric v1.36.0
 	go.opentelemetry.io/otel/sdk/metric v1.36.0
@@ -27,10 +27,10 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
-	go.opentelemetry.io/collector/consumer v1.34.1 // indirect
-	go.opentelemetry.io/collector/featuregate v1.34.1 // indirect
+	go.opentelemetry.io/collector/consumer v1.35.0 // indirect
+	go.opentelemetry.io/collector/featuregate v1.35.0 // indirect
 	go.opentelemetry.io/collector/internal/telemetry v0.128.1 // indirect
-	go.opentelemetry.io/collector/pdata v1.34.1 // indirect
+	go.opentelemetry.io/collector/pdata v1.35.0 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.11.0 // indirect
 	go.opentelemetry.io/otel/log v0.12.2 // indirect
 	go.opentelemetry.io/otel/sdk v1.36.0 // indirect

--- a/receiver/receiverhelper/go.mod
+++ b/receiver/receiverhelper/go.mod
@@ -5,8 +5,8 @@ go 1.23.0
 require (
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/component v1.35.0
-	go.opentelemetry.io/collector/component/componenttest v0.128.1
-	go.opentelemetry.io/collector/pipeline v0.128.1
+	go.opentelemetry.io/collector/component/componenttest v0.129.0
+	go.opentelemetry.io/collector/pipeline v0.129.0
 	go.opentelemetry.io/collector/receiver v1.35.0
 	go.opentelemetry.io/otel v1.36.0
 	go.opentelemetry.io/otel/metric v1.36.0
@@ -29,7 +29,7 @@ require (
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/collector/consumer v1.35.0 // indirect
 	go.opentelemetry.io/collector/featuregate v1.35.0 // indirect
-	go.opentelemetry.io/collector/internal/telemetry v0.128.1 // indirect
+	go.opentelemetry.io/collector/internal/telemetry v0.129.0 // indirect
 	go.opentelemetry.io/collector/pdata v1.35.0 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.11.0 // indirect
 	go.opentelemetry.io/otel/log v0.12.2 // indirect

--- a/receiver/receivertest/go.mod
+++ b/receiver/receivertest/go.mod
@@ -5,15 +5,15 @@ go 1.23.0
 require (
 	github.com/google/uuid v1.6.0
 	github.com/stretchr/testify v1.10.0
-	go.opentelemetry.io/collector/component v1.34.1
+	go.opentelemetry.io/collector/component v1.35.0
 	go.opentelemetry.io/collector/component/componenttest v0.128.1
-	go.opentelemetry.io/collector/consumer v1.34.1
+	go.opentelemetry.io/collector/consumer v1.35.0
 	go.opentelemetry.io/collector/consumer/consumererror v0.128.1
 	go.opentelemetry.io/collector/consumer/consumertest v0.128.1
 	go.opentelemetry.io/collector/consumer/xconsumer v0.128.1
-	go.opentelemetry.io/collector/pdata v1.34.1
+	go.opentelemetry.io/collector/pdata v1.35.0
 	go.opentelemetry.io/collector/pipeline v0.128.1
-	go.opentelemetry.io/collector/receiver v1.34.1
+	go.opentelemetry.io/collector/receiver v1.35.0
 	go.opentelemetry.io/collector/receiver/xreceiver v0.128.1
 	go.uber.org/goleak v1.3.0
 )
@@ -29,7 +29,7 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
-	go.opentelemetry.io/collector/featuregate v1.34.1 // indirect
+	go.opentelemetry.io/collector/featuregate v1.35.0 // indirect
 	go.opentelemetry.io/collector/internal/telemetry v0.128.1 // indirect
 	go.opentelemetry.io/collector/pdata/pprofile v0.128.1 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.11.0 // indirect

--- a/receiver/receivertest/go.mod
+++ b/receiver/receivertest/go.mod
@@ -6,15 +6,15 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/component v1.35.0
-	go.opentelemetry.io/collector/component/componenttest v0.128.1
+	go.opentelemetry.io/collector/component/componenttest v0.129.0
 	go.opentelemetry.io/collector/consumer v1.35.0
-	go.opentelemetry.io/collector/consumer/consumererror v0.128.1
-	go.opentelemetry.io/collector/consumer/consumertest v0.128.1
-	go.opentelemetry.io/collector/consumer/xconsumer v0.128.1
+	go.opentelemetry.io/collector/consumer/consumererror v0.129.0
+	go.opentelemetry.io/collector/consumer/consumertest v0.129.0
+	go.opentelemetry.io/collector/consumer/xconsumer v0.129.0
 	go.opentelemetry.io/collector/pdata v1.35.0
-	go.opentelemetry.io/collector/pipeline v0.128.1
+	go.opentelemetry.io/collector/pipeline v0.129.0
 	go.opentelemetry.io/collector/receiver v1.35.0
-	go.opentelemetry.io/collector/receiver/xreceiver v0.128.1
+	go.opentelemetry.io/collector/receiver/xreceiver v0.129.0
 	go.uber.org/goleak v1.3.0
 )
 
@@ -30,8 +30,8 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/collector/featuregate v1.35.0 // indirect
-	go.opentelemetry.io/collector/internal/telemetry v0.128.1 // indirect
-	go.opentelemetry.io/collector/pdata/pprofile v0.128.1 // indirect
+	go.opentelemetry.io/collector/internal/telemetry v0.129.0 // indirect
+	go.opentelemetry.io/collector/pdata/pprofile v0.129.0 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.11.0 // indirect
 	go.opentelemetry.io/otel v1.36.0 // indirect
 	go.opentelemetry.io/otel/log v0.12.2 // indirect

--- a/receiver/xreceiver/go.mod
+++ b/receiver/xreceiver/go.mod
@@ -5,9 +5,9 @@ go 1.23.0
 require (
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/component v1.35.0
-	go.opentelemetry.io/collector/consumer/consumertest v0.128.1
-	go.opentelemetry.io/collector/consumer/xconsumer v0.128.1
-	go.opentelemetry.io/collector/pipeline v0.128.1
+	go.opentelemetry.io/collector/consumer/consumertest v0.129.0
+	go.opentelemetry.io/collector/consumer/xconsumer v0.129.0
+	go.opentelemetry.io/collector/pipeline v0.129.0
 	go.opentelemetry.io/collector/receiver v1.35.0
 )
 
@@ -25,9 +25,9 @@ require (
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/collector/consumer v1.35.0 // indirect
 	go.opentelemetry.io/collector/featuregate v1.35.0 // indirect
-	go.opentelemetry.io/collector/internal/telemetry v0.128.1 // indirect
+	go.opentelemetry.io/collector/internal/telemetry v0.129.0 // indirect
 	go.opentelemetry.io/collector/pdata v1.35.0 // indirect
-	go.opentelemetry.io/collector/pdata/pprofile v0.128.1 // indirect
+	go.opentelemetry.io/collector/pdata/pprofile v0.129.0 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.11.0 // indirect
 	go.opentelemetry.io/otel v1.36.0 // indirect
 	go.opentelemetry.io/otel/log v0.12.2 // indirect

--- a/receiver/xreceiver/go.mod
+++ b/receiver/xreceiver/go.mod
@@ -4,11 +4,11 @@ go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0
-	go.opentelemetry.io/collector/component v1.34.1
+	go.opentelemetry.io/collector/component v1.35.0
 	go.opentelemetry.io/collector/consumer/consumertest v0.128.1
 	go.opentelemetry.io/collector/consumer/xconsumer v0.128.1
 	go.opentelemetry.io/collector/pipeline v0.128.1
-	go.opentelemetry.io/collector/receiver v1.34.1
+	go.opentelemetry.io/collector/receiver v1.35.0
 )
 
 require (
@@ -23,10 +23,10 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
-	go.opentelemetry.io/collector/consumer v1.34.1 // indirect
-	go.opentelemetry.io/collector/featuregate v1.34.1 // indirect
+	go.opentelemetry.io/collector/consumer v1.35.0 // indirect
+	go.opentelemetry.io/collector/featuregate v1.35.0 // indirect
 	go.opentelemetry.io/collector/internal/telemetry v0.128.1 // indirect
-	go.opentelemetry.io/collector/pdata v1.34.1 // indirect
+	go.opentelemetry.io/collector/pdata v1.35.0 // indirect
 	go.opentelemetry.io/collector/pdata/pprofile v0.128.1 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.11.0 // indirect
 	go.opentelemetry.io/otel v1.36.0 // indirect

--- a/scraper/go.mod
+++ b/scraper/go.mod
@@ -4,9 +4,9 @@ go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0
-	go.opentelemetry.io/collector/component v1.34.1
+	go.opentelemetry.io/collector/component v1.35.0
 	go.opentelemetry.io/collector/component/componenttest v0.128.1
-	go.opentelemetry.io/collector/pdata v1.34.1
+	go.opentelemetry.io/collector/pdata v1.35.0
 	go.opentelemetry.io/collector/pipeline v0.128.1
 	go.uber.org/goleak v1.3.0
 	go.uber.org/multierr v1.11.0
@@ -24,7 +24,7 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
-	go.opentelemetry.io/collector/featuregate v1.34.1 // indirect
+	go.opentelemetry.io/collector/featuregate v1.35.0 // indirect
 	go.opentelemetry.io/collector/internal/telemetry v0.128.1 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.11.0 // indirect
 	go.opentelemetry.io/otel v1.36.0 // indirect

--- a/scraper/go.mod
+++ b/scraper/go.mod
@@ -5,9 +5,9 @@ go 1.23.0
 require (
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/component v1.35.0
-	go.opentelemetry.io/collector/component/componenttest v0.128.1
+	go.opentelemetry.io/collector/component/componenttest v0.129.0
 	go.opentelemetry.io/collector/pdata v1.35.0
-	go.opentelemetry.io/collector/pipeline v0.128.1
+	go.opentelemetry.io/collector/pipeline v0.129.0
 	go.uber.org/goleak v1.3.0
 	go.uber.org/multierr v1.11.0
 )
@@ -25,7 +25,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/collector/featuregate v1.35.0 // indirect
-	go.opentelemetry.io/collector/internal/telemetry v0.128.1 // indirect
+	go.opentelemetry.io/collector/internal/telemetry v0.129.0 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.11.0 // indirect
 	go.opentelemetry.io/otel v1.36.0 // indirect
 	go.opentelemetry.io/otel/log v0.12.2 // indirect

--- a/scraper/scraperhelper/go.mod
+++ b/scraper/scraperhelper/go.mod
@@ -5,16 +5,16 @@ go 1.23.0
 require (
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/component v1.35.0
-	go.opentelemetry.io/collector/component/componenttest v0.128.1
+	go.opentelemetry.io/collector/component/componenttest v0.129.0
 	go.opentelemetry.io/collector/consumer v1.35.0
-	go.opentelemetry.io/collector/consumer/consumertest v0.128.1
+	go.opentelemetry.io/collector/consumer/consumertest v0.129.0
 	go.opentelemetry.io/collector/pdata v1.35.0
-	go.opentelemetry.io/collector/pdata/testdata v0.128.1
-	go.opentelemetry.io/collector/pipeline v0.128.1
+	go.opentelemetry.io/collector/pdata/testdata v0.129.0
+	go.opentelemetry.io/collector/pipeline v0.129.0
 	go.opentelemetry.io/collector/receiver v1.35.0
-	go.opentelemetry.io/collector/receiver/receiverhelper v0.128.1
-	go.opentelemetry.io/collector/receiver/receivertest v0.128.1
-	go.opentelemetry.io/collector/scraper v0.128.1
+	go.opentelemetry.io/collector/receiver/receiverhelper v0.129.0
+	go.opentelemetry.io/collector/receiver/receivertest v0.129.0
+	go.opentelemetry.io/collector/scraper v0.129.0
 	go.opentelemetry.io/otel v1.36.0
 	go.opentelemetry.io/otel/metric v1.36.0
 	go.opentelemetry.io/otel/sdk v1.36.0
@@ -37,12 +37,12 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
-	go.opentelemetry.io/collector/consumer/consumererror v0.128.1 // indirect
-	go.opentelemetry.io/collector/consumer/xconsumer v0.128.1 // indirect
+	go.opentelemetry.io/collector/consumer/consumererror v0.129.0 // indirect
+	go.opentelemetry.io/collector/consumer/xconsumer v0.129.0 // indirect
 	go.opentelemetry.io/collector/featuregate v1.35.0 // indirect
-	go.opentelemetry.io/collector/internal/telemetry v0.128.1 // indirect
-	go.opentelemetry.io/collector/pdata/pprofile v0.128.1 // indirect
-	go.opentelemetry.io/collector/receiver/xreceiver v0.128.1 // indirect
+	go.opentelemetry.io/collector/internal/telemetry v0.129.0 // indirect
+	go.opentelemetry.io/collector/pdata/pprofile v0.129.0 // indirect
+	go.opentelemetry.io/collector/receiver/xreceiver v0.129.0 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.11.0 // indirect
 	go.opentelemetry.io/otel/log v0.12.2 // indirect
 	golang.org/x/net v0.39.0 // indirect

--- a/scraper/scraperhelper/go.mod
+++ b/scraper/scraperhelper/go.mod
@@ -4,14 +4,14 @@ go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0
-	go.opentelemetry.io/collector/component v1.34.1
+	go.opentelemetry.io/collector/component v1.35.0
 	go.opentelemetry.io/collector/component/componenttest v0.128.1
-	go.opentelemetry.io/collector/consumer v1.34.1
+	go.opentelemetry.io/collector/consumer v1.35.0
 	go.opentelemetry.io/collector/consumer/consumertest v0.128.1
-	go.opentelemetry.io/collector/pdata v1.34.1
+	go.opentelemetry.io/collector/pdata v1.35.0
 	go.opentelemetry.io/collector/pdata/testdata v0.128.1
 	go.opentelemetry.io/collector/pipeline v0.128.1
-	go.opentelemetry.io/collector/receiver v1.34.1
+	go.opentelemetry.io/collector/receiver v1.35.0
 	go.opentelemetry.io/collector/receiver/receiverhelper v0.128.1
 	go.opentelemetry.io/collector/receiver/receivertest v0.128.1
 	go.opentelemetry.io/collector/scraper v0.128.1
@@ -39,7 +39,7 @@ require (
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/collector/consumer/consumererror v0.128.1 // indirect
 	go.opentelemetry.io/collector/consumer/xconsumer v0.128.1 // indirect
-	go.opentelemetry.io/collector/featuregate v1.34.1 // indirect
+	go.opentelemetry.io/collector/featuregate v1.35.0 // indirect
 	go.opentelemetry.io/collector/internal/telemetry v0.128.1 // indirect
 	go.opentelemetry.io/collector/pdata/pprofile v0.128.1 // indirect
 	go.opentelemetry.io/collector/receiver/xreceiver v0.128.1 // indirect

--- a/scraper/scrapertest/go.mod
+++ b/scraper/scrapertest/go.mod
@@ -5,8 +5,8 @@ go 1.23.0
 require (
 	github.com/google/uuid v1.6.0
 	go.opentelemetry.io/collector/component v1.35.0
-	go.opentelemetry.io/collector/component/componenttest v0.128.1
-	go.opentelemetry.io/collector/scraper v0.128.1
+	go.opentelemetry.io/collector/component/componenttest v0.129.0
+	go.opentelemetry.io/collector/scraper v0.129.0
 )
 
 require (
@@ -19,9 +19,9 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/collector/featuregate v1.35.0 // indirect
-	go.opentelemetry.io/collector/internal/telemetry v0.128.1 // indirect
+	go.opentelemetry.io/collector/internal/telemetry v0.129.0 // indirect
 	go.opentelemetry.io/collector/pdata v1.35.0 // indirect
-	go.opentelemetry.io/collector/pipeline v0.128.1 // indirect
+	go.opentelemetry.io/collector/pipeline v0.129.0 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.11.0 // indirect
 	go.opentelemetry.io/otel v1.36.0 // indirect
 	go.opentelemetry.io/otel/log v0.12.2 // indirect

--- a/scraper/scrapertest/go.mod
+++ b/scraper/scrapertest/go.mod
@@ -4,7 +4,7 @@ go 1.23.0
 
 require (
 	github.com/google/uuid v1.6.0
-	go.opentelemetry.io/collector/component v1.34.1
+	go.opentelemetry.io/collector/component v1.35.0
 	go.opentelemetry.io/collector/component/componenttest v0.128.1
 	go.opentelemetry.io/collector/scraper v0.128.1
 )
@@ -18,9 +18,9 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
-	go.opentelemetry.io/collector/featuregate v1.34.1 // indirect
+	go.opentelemetry.io/collector/featuregate v1.35.0 // indirect
 	go.opentelemetry.io/collector/internal/telemetry v0.128.1 // indirect
-	go.opentelemetry.io/collector/pdata v1.34.1 // indirect
+	go.opentelemetry.io/collector/pdata v1.35.0 // indirect
 	go.opentelemetry.io/collector/pipeline v0.128.1 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.11.0 // indirect
 	go.opentelemetry.io/otel v1.36.0 // indirect

--- a/service/go.mod
+++ b/service/go.mod
@@ -9,39 +9,39 @@ require (
 	github.com/shirou/gopsutil/v4 v4.25.5
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector v0.128.1
-	go.opentelemetry.io/collector/component v1.34.1
+	go.opentelemetry.io/collector/component v1.35.0
 	go.opentelemetry.io/collector/component/componentstatus v0.128.1
 	go.opentelemetry.io/collector/component/componenttest v0.128.1
 	go.opentelemetry.io/collector/config/confighttp v0.128.1
 	go.opentelemetry.io/collector/config/configtelemetry v0.128.1
-	go.opentelemetry.io/collector/confmap v1.34.1
+	go.opentelemetry.io/collector/confmap v1.35.0
 	go.opentelemetry.io/collector/confmap/xconfmap v0.128.1
 	go.opentelemetry.io/collector/connector v0.128.1
 	go.opentelemetry.io/collector/connector/connectortest v0.128.1
 	go.opentelemetry.io/collector/connector/xconnector v0.128.1
-	go.opentelemetry.io/collector/consumer v1.34.1
+	go.opentelemetry.io/collector/consumer v1.35.0
 	go.opentelemetry.io/collector/consumer/consumertest v0.128.1
 	go.opentelemetry.io/collector/consumer/xconsumer v0.128.1
 	go.opentelemetry.io/collector/exporter v0.128.1
 	go.opentelemetry.io/collector/exporter/exportertest v0.128.1
 	go.opentelemetry.io/collector/exporter/xexporter v0.128.1
-	go.opentelemetry.io/collector/extension v1.34.1
+	go.opentelemetry.io/collector/extension v1.35.0
 	go.opentelemetry.io/collector/extension/extensioncapabilities v0.128.1
 	go.opentelemetry.io/collector/extension/extensiontest v0.128.1
 	go.opentelemetry.io/collector/extension/zpagesextension v0.128.1
-	go.opentelemetry.io/collector/featuregate v1.34.1
+	go.opentelemetry.io/collector/featuregate v1.35.0
 	go.opentelemetry.io/collector/internal/fanoutconsumer v0.128.1
 	go.opentelemetry.io/collector/internal/telemetry v0.128.1
 	go.opentelemetry.io/collector/otelcol v0.128.1
-	go.opentelemetry.io/collector/pdata v1.34.1
+	go.opentelemetry.io/collector/pdata v1.35.0
 	go.opentelemetry.io/collector/pdata/pprofile v0.128.1
 	go.opentelemetry.io/collector/pdata/testdata v0.128.1
 	go.opentelemetry.io/collector/pipeline v0.128.1
 	go.opentelemetry.io/collector/pipeline/xpipeline v0.128.1
-	go.opentelemetry.io/collector/processor v1.34.1
+	go.opentelemetry.io/collector/processor v1.35.0
 	go.opentelemetry.io/collector/processor/processortest v0.128.1
 	go.opentelemetry.io/collector/processor/xprocessor v0.128.1
-	go.opentelemetry.io/collector/receiver v1.34.1
+	go.opentelemetry.io/collector/receiver v1.35.0
 	go.opentelemetry.io/collector/receiver/receivertest v0.128.1
 	go.opentelemetry.io/collector/receiver/xreceiver v0.128.1
 	go.opentelemetry.io/collector/service/hostcapabilities v0.128.1
@@ -102,14 +102,14 @@ require (
 	github.com/tklauser/numcpus v0.6.1 // indirect
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
-	go.opentelemetry.io/collector/client v1.34.1 // indirect
+	go.opentelemetry.io/collector/client v1.35.0 // indirect
 	go.opentelemetry.io/collector/config/configauth v0.128.1 // indirect
-	go.opentelemetry.io/collector/config/configcompression v1.34.1 // indirect
+	go.opentelemetry.io/collector/config/configcompression v1.35.0 // indirect
 	go.opentelemetry.io/collector/config/configmiddleware v0.128.1 // indirect
-	go.opentelemetry.io/collector/config/configopaque v1.34.1 // indirect
-	go.opentelemetry.io/collector/config/configtls v1.34.1 // indirect
+	go.opentelemetry.io/collector/config/configopaque v1.35.0 // indirect
+	go.opentelemetry.io/collector/config/configtls v1.35.0 // indirect
 	go.opentelemetry.io/collector/consumer/consumererror v0.128.1 // indirect
-	go.opentelemetry.io/collector/extension/extensionauth v1.34.1 // indirect
+	go.opentelemetry.io/collector/extension/extensionauth v1.35.0 // indirect
 	go.opentelemetry.io/collector/extension/extensionmiddleware v0.128.1 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.11.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.61.0 // indirect

--- a/service/go.mod
+++ b/service/go.mod
@@ -8,43 +8,43 @@ require (
 	github.com/prometheus/common v0.64.0
 	github.com/shirou/gopsutil/v4 v4.25.5
 	github.com/stretchr/testify v1.10.0
-	go.opentelemetry.io/collector v0.128.1
+	go.opentelemetry.io/collector v0.129.0
 	go.opentelemetry.io/collector/component v1.35.0
-	go.opentelemetry.io/collector/component/componentstatus v0.128.1
-	go.opentelemetry.io/collector/component/componenttest v0.128.1
-	go.opentelemetry.io/collector/config/confighttp v0.128.1
-	go.opentelemetry.io/collector/config/configtelemetry v0.128.1
+	go.opentelemetry.io/collector/component/componentstatus v0.129.0
+	go.opentelemetry.io/collector/component/componenttest v0.129.0
+	go.opentelemetry.io/collector/config/confighttp v0.129.0
+	go.opentelemetry.io/collector/config/configtelemetry v0.129.0
 	go.opentelemetry.io/collector/confmap v1.35.0
-	go.opentelemetry.io/collector/confmap/xconfmap v0.128.1
-	go.opentelemetry.io/collector/connector v0.128.1
-	go.opentelemetry.io/collector/connector/connectortest v0.128.1
-	go.opentelemetry.io/collector/connector/xconnector v0.128.1
+	go.opentelemetry.io/collector/confmap/xconfmap v0.129.0
+	go.opentelemetry.io/collector/connector v0.129.0
+	go.opentelemetry.io/collector/connector/connectortest v0.129.0
+	go.opentelemetry.io/collector/connector/xconnector v0.129.0
 	go.opentelemetry.io/collector/consumer v1.35.0
-	go.opentelemetry.io/collector/consumer/consumertest v0.128.1
-	go.opentelemetry.io/collector/consumer/xconsumer v0.128.1
-	go.opentelemetry.io/collector/exporter v0.128.1
-	go.opentelemetry.io/collector/exporter/exportertest v0.128.1
-	go.opentelemetry.io/collector/exporter/xexporter v0.128.1
+	go.opentelemetry.io/collector/consumer/consumertest v0.129.0
+	go.opentelemetry.io/collector/consumer/xconsumer v0.129.0
+	go.opentelemetry.io/collector/exporter v0.129.0
+	go.opentelemetry.io/collector/exporter/exportertest v0.129.0
+	go.opentelemetry.io/collector/exporter/xexporter v0.129.0
 	go.opentelemetry.io/collector/extension v1.35.0
-	go.opentelemetry.io/collector/extension/extensioncapabilities v0.128.1
-	go.opentelemetry.io/collector/extension/extensiontest v0.128.1
-	go.opentelemetry.io/collector/extension/zpagesextension v0.128.1
+	go.opentelemetry.io/collector/extension/extensioncapabilities v0.129.0
+	go.opentelemetry.io/collector/extension/extensiontest v0.129.0
+	go.opentelemetry.io/collector/extension/zpagesextension v0.129.0
 	go.opentelemetry.io/collector/featuregate v1.35.0
-	go.opentelemetry.io/collector/internal/fanoutconsumer v0.128.1
-	go.opentelemetry.io/collector/internal/telemetry v0.128.1
-	go.opentelemetry.io/collector/otelcol v0.128.1
+	go.opentelemetry.io/collector/internal/fanoutconsumer v0.129.0
+	go.opentelemetry.io/collector/internal/telemetry v0.129.0
+	go.opentelemetry.io/collector/otelcol v0.129.0
 	go.opentelemetry.io/collector/pdata v1.35.0
-	go.opentelemetry.io/collector/pdata/pprofile v0.128.1
-	go.opentelemetry.io/collector/pdata/testdata v0.128.1
-	go.opentelemetry.io/collector/pipeline v0.128.1
-	go.opentelemetry.io/collector/pipeline/xpipeline v0.128.1
+	go.opentelemetry.io/collector/pdata/pprofile v0.129.0
+	go.opentelemetry.io/collector/pdata/testdata v0.129.0
+	go.opentelemetry.io/collector/pipeline v0.129.0
+	go.opentelemetry.io/collector/pipeline/xpipeline v0.129.0
 	go.opentelemetry.io/collector/processor v1.35.0
-	go.opentelemetry.io/collector/processor/processortest v0.128.1
-	go.opentelemetry.io/collector/processor/xprocessor v0.128.1
+	go.opentelemetry.io/collector/processor/processortest v0.129.0
+	go.opentelemetry.io/collector/processor/xprocessor v0.129.0
 	go.opentelemetry.io/collector/receiver v1.35.0
-	go.opentelemetry.io/collector/receiver/receivertest v0.128.1
-	go.opentelemetry.io/collector/receiver/xreceiver v0.128.1
-	go.opentelemetry.io/collector/service/hostcapabilities v0.128.1
+	go.opentelemetry.io/collector/receiver/receivertest v0.129.0
+	go.opentelemetry.io/collector/receiver/xreceiver v0.129.0
+	go.opentelemetry.io/collector/service/hostcapabilities v0.129.0
 	go.opentelemetry.io/contrib/otelconf v0.16.0
 	go.opentelemetry.io/contrib/propagators/b3 v1.36.0
 	go.opentelemetry.io/otel v1.36.0
@@ -103,14 +103,14 @@ require (
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/collector/client v1.35.0 // indirect
-	go.opentelemetry.io/collector/config/configauth v0.128.1 // indirect
+	go.opentelemetry.io/collector/config/configauth v0.129.0 // indirect
 	go.opentelemetry.io/collector/config/configcompression v1.35.0 // indirect
-	go.opentelemetry.io/collector/config/configmiddleware v0.128.1 // indirect
+	go.opentelemetry.io/collector/config/configmiddleware v0.129.0 // indirect
 	go.opentelemetry.io/collector/config/configopaque v1.35.0 // indirect
 	go.opentelemetry.io/collector/config/configtls v1.35.0 // indirect
-	go.opentelemetry.io/collector/consumer/consumererror v0.128.1 // indirect
+	go.opentelemetry.io/collector/consumer/consumererror v0.129.0 // indirect
 	go.opentelemetry.io/collector/extension/extensionauth v1.35.0 // indirect
-	go.opentelemetry.io/collector/extension/extensionmiddleware v0.128.1 // indirect
+	go.opentelemetry.io/collector/extension/extensionmiddleware v0.129.0 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.11.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.61.0 // indirect
 	go.opentelemetry.io/contrib/zpages v0.61.0 // indirect

--- a/service/hostcapabilities/go.mod
+++ b/service/hostcapabilities/go.mod
@@ -4,8 +4,8 @@ go 1.23.0
 
 require (
 	go.opentelemetry.io/collector/component v1.35.0
-	go.opentelemetry.io/collector/pipeline v0.128.1
-	go.opentelemetry.io/collector/service v0.128.1
+	go.opentelemetry.io/collector/pipeline v0.129.0
+	go.opentelemetry.io/collector/service v0.129.0
 )
 
 require (
@@ -16,7 +16,7 @@ require (
 	github.com/hashicorp/go-version v1.7.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/collector/featuregate v1.35.0 // indirect
-	go.opentelemetry.io/collector/internal/telemetry v0.128.1 // indirect
+	go.opentelemetry.io/collector/internal/telemetry v0.129.0 // indirect
 	go.opentelemetry.io/collector/pdata v1.35.0 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.11.0 // indirect
 	go.opentelemetry.io/otel v1.36.0 // indirect

--- a/service/hostcapabilities/go.mod
+++ b/service/hostcapabilities/go.mod
@@ -3,7 +3,7 @@ module go.opentelemetry.io/collector/service/hostcapabilities
 go 1.23.0
 
 require (
-	go.opentelemetry.io/collector/component v1.34.1
+	go.opentelemetry.io/collector/component v1.35.0
 	go.opentelemetry.io/collector/pipeline v0.128.1
 	go.opentelemetry.io/collector/service v0.128.1
 )
@@ -15,9 +15,9 @@ require (
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/hashicorp/go-version v1.7.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
-	go.opentelemetry.io/collector/featuregate v1.34.1 // indirect
+	go.opentelemetry.io/collector/featuregate v1.35.0 // indirect
 	go.opentelemetry.io/collector/internal/telemetry v0.128.1 // indirect
-	go.opentelemetry.io/collector/pdata v1.34.1 // indirect
+	go.opentelemetry.io/collector/pdata v1.35.0 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.11.0 // indirect
 	go.opentelemetry.io/otel v1.36.0 // indirect
 	go.opentelemetry.io/otel/log v0.12.2 // indirect

--- a/versions.yaml
+++ b/versions.yaml
@@ -26,7 +26,7 @@ module-sets:
       - go.opentelemetry.io/collector/processor
       - go.opentelemetry.io/collector/receiver
   beta:
-    version: v0.128.1
+    version: v0.129.0
     modules:
       - go.opentelemetry.io/collector
       - go.opentelemetry.io/collector/internal/memorylimiter

--- a/versions.yaml
+++ b/versions.yaml
@@ -3,7 +3,7 @@
 
 module-sets:
   stable:
-    version: v1.34.1
+    version: v1.35.0
     modules:
       - go.opentelemetry.io/collector/client
       - go.opentelemetry.io/collector/featuregate


### PR DESCRIPTION

The following commands were run to prepare this release:
- make chlog-update VERSION=v1.35.0/v0.129.0
- make prepare-release PREVIOUS_VERSION=1[.]34[.]1 RELEASE_CANDIDATE=1.35.0 MODSET=stable
- make prepare-release PREVIOUS_VERSION=0[.]128[.]1 RELEASE_CANDIDATE=0.129.0 MODSET=beta
